### PR TITLE
[Issue #3] API de categorías por tablero + seed defaults

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { BudgetsModule } from './budgets/budgets.module';
 import { ExpensesModule } from './expenses/expenses.module';
 import { BotModule } from './bot/bot.module';
 import { CardsModule } from './cards/cards.module';
+import { CategoriesModule } from './categories/categories.module';
 
 @Module({
   imports: [
@@ -45,6 +46,7 @@ import { CardsModule } from './cards/cards.module';
     ExpensesModule,
     BotModule,
     CardsModule,
+    CategoriesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -1,0 +1,101 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+  Query,
+  BadRequestException,
+} from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GetUser } from '../auth/decorators/get-user.decorator';
+import { UserDocument } from '../users/user.schema';
+
+@Controller('categories')
+@UseGuards(JwtAuthGuard)
+export class CategoriesController {
+  constructor(private readonly categoriesService: CategoriesService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Body() createCategoryDto: CreateCategoryDto,
+    @GetUser() user: UserDocument,
+  ) {
+    const category = await this.categoriesService.create(
+      createCategoryDto,
+      user._id.toString(),
+    );
+    return {
+      message: 'Categoría creada exitosamente',
+      category,
+    };
+  }
+
+  @Get()
+  async findAllByBoard(
+    @Query('boardId') boardId: string,
+    @GetUser() user: UserDocument,
+    @Query('tripId') tripId?: string,
+    @Query('includeInactive') includeInactive?: string,
+  ) {
+    const resolvedBoardId = boardId || tripId;
+    if (!resolvedBoardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+
+    const categories = await this.categoriesService.findAllByBoard(
+      resolvedBoardId,
+      user._id.toString(),
+      includeInactive === 'true',
+    );
+    return { categories };
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string, @GetUser() user: UserDocument) {
+    const category = await this.categoriesService.findOne(
+      id,
+      user._id.toString(),
+    );
+    return { category };
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() updateCategoryDto: UpdateCategoryDto,
+    @GetUser() user: UserDocument,
+  ) {
+    const category = await this.categoriesService.update(
+      id,
+      updateCategoryDto,
+      user._id.toString(),
+    );
+    return {
+      message: 'Categoría actualizada exitosamente',
+      category,
+    };
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  async archive(@Param('id') id: string, @GetUser() user: UserDocument) {
+    const category = await this.categoriesService.archive(
+      id,
+      user._id.toString(),
+    );
+    return {
+      message: 'Categoría archivada exitosamente',
+      category,
+    };
+  }
+}

--- a/src/categories/categories.module.ts
+++ b/src/categories/categories.module.ts
@@ -1,0 +1,19 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { CategoriesService } from './categories.service';
+import { CategoriesController } from './categories.controller';
+import { Category, CategorySchema } from './category.schema';
+import { ParticipantsModule } from '../participants/participants.module';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Category.name, schema: CategorySchema },
+    ]),
+    forwardRef(() => ParticipantsModule),
+  ],
+  controllers: [CategoriesController],
+  providers: [CategoriesService],
+  exports: [CategoriesService, MongooseModule],
+})
+export class CategoriesModule {}

--- a/src/categories/categories.service.spec.ts
+++ b/src/categories/categories.service.spec.ts
@@ -143,6 +143,36 @@ describe('CategoriesService', () => {
     });
   });
 
+  describe('update reactivation', () => {
+    it('should reject reactivating when another active category has the same name', async () => {
+      const archivedCategoryId = new Types.ObjectId();
+      const categoryDoc = {
+        _id: archivedCategoryId,
+        tripId: boardId,
+        name: 'Comida',
+        isActive: false,
+        save: jest.fn(),
+      };
+      categoryModel.findById.mockResolvedValue(categoryDoc);
+      participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+      categoryModel.findOne.mockResolvedValue({
+        _id: categoryId,
+        name: 'Comida',
+        isActive: true,
+      });
+
+      await expect(
+        service.update(
+          archivedCategoryId.toString(),
+          { isActive: true },
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(categoryDoc.save).not.toHaveBeenCalled();
+    });
+  });
+
   describe('findOne', () => {
     it('should throw when category does not exist', async () => {
       categoryModel.findById.mockReturnValue({

--- a/src/categories/categories.service.spec.ts
+++ b/src/categories/categories.service.spec.ts
@@ -1,0 +1,157 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import {
+  ForbiddenException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { Types } from 'mongoose';
+import { CategoriesService } from './categories.service';
+import { Category } from './category.schema';
+import { ParticipantsService } from '../participants/participants.service';
+import { DEFAULT_CATEGORIES } from './constants/default-categories';
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+
+  const boardId = new Types.ObjectId();
+  const categoryId = new Types.ObjectId();
+  const userId = new Types.ObjectId().toString();
+
+  const categoryModel = {
+    insertMany: jest.fn(),
+    find: jest.fn(),
+    findById: jest.fn(),
+    findOne: jest.fn(),
+    deleteMany: jest.fn(),
+  };
+
+  const participantsService = {
+    ensureParticipantAccess: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategoriesService,
+        { provide: getModelToken(Category.name), useValue: categoryModel },
+        { provide: ParticipantsService, useValue: participantsService },
+      ],
+    }).compile();
+
+    service = module.get(CategoriesService);
+  });
+
+  describe('seedDefaults', () => {
+    it('should insert default categories for a board', async () => {
+      const seeded = DEFAULT_CATEGORIES.map((item) => ({
+        _id: new Types.ObjectId(),
+        tripId: boardId,
+        ...item,
+        isActive: true,
+        isDefault: true,
+      }));
+      categoryModel.insertMany.mockResolvedValue(seeded);
+
+      const result = await service.seedDefaults(boardId.toString());
+
+      expect(categoryModel.insertMany).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            tripId: boardId,
+            name: 'Comida',
+            isDefault: true,
+            isActive: true,
+          }),
+        ]),
+      );
+      expect(result).toHaveLength(DEFAULT_CATEGORIES.length);
+    });
+  });
+
+  describe('findAllByBoard', () => {
+    it('should require participant access', async () => {
+      participantsService.ensureParticipantAccess.mockRejectedValue(
+        new ForbiddenException('No tienes acceso a este viaje'),
+      );
+
+      await expect(
+        service.findAllByBoard(boardId.toString(), userId),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('should return active categories sorted for members', async () => {
+      participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+      const chain = {
+        sort: jest.fn().mockReturnThis(),
+        lean: jest
+          .fn()
+          .mockResolvedValue([
+            { _id: categoryId, name: 'Comida', isActive: true },
+          ]),
+      };
+      categoryModel.find.mockReturnValue(chain);
+
+      const result = await service.findAllByBoard(boardId.toString(), userId);
+
+      expect(categoryModel.find).toHaveBeenCalledWith({
+        tripId: boardId,
+        isActive: true,
+      });
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('create', () => {
+    it('should reject duplicate active category names', async () => {
+      participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+      categoryModel.findOne.mockResolvedValue({
+        _id: categoryId,
+        name: 'Comida',
+      });
+
+      await expect(
+        service.create({ boardId: boardId.toString(), name: 'comida' }, userId),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('archive', () => {
+    it('should soft-delete by setting isActive false', async () => {
+      const categoryDoc = {
+        _id: categoryId,
+        tripId: boardId,
+        name: 'Comida',
+        isActive: true,
+        save: jest.fn().mockResolvedValue({
+          _id: categoryId,
+          name: 'Comida',
+          isActive: false,
+        }),
+      };
+      categoryModel.findById.mockResolvedValue(categoryDoc);
+      participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+      categoryModel.findOne.mockResolvedValue(null);
+
+      const result = await service.archive(categoryId.toString(), userId);
+
+      expect(categoryDoc.isActive).toBe(false);
+      expect(categoryDoc.save).toHaveBeenCalled();
+      expect(result.isActive).toBe(false);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should throw when category does not exist', async () => {
+      categoryModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.findOne(categoryId.toString(), userId),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -53,19 +53,10 @@ export class CategoriesService {
     await this.participantsService.ensureParticipantAccess(boardId, userId);
 
     const normalizedName = createCategoryDto.name.trim();
-    const existing = await this.categoryModel.findOne({
-      tripId: new Types.ObjectId(boardId),
-      name: {
-        $regex: new RegExp(`^${this.escapeRegex(normalizedName)}$`, 'i'),
-      },
-      isActive: true,
-    });
-
-    if (existing) {
-      throw new BadRequestException(
-        'Ya existe una categoría activa con ese nombre en este tablero',
-      );
-    }
+    await this.assertNoActiveDuplicateName(
+      new Types.ObjectId(boardId),
+      normalizedName,
+    );
 
     const category = new this.categoryModel({
       tripId: new Types.ObjectId(boardId),
@@ -133,21 +124,11 @@ export class CategoriesService {
 
     if (updateCategoryDto.name !== undefined) {
       const normalizedName = updateCategoryDto.name.trim();
-      const duplicate = await this.categoryModel.findOne({
-        _id: { $ne: category._id },
-        tripId: category.tripId,
-        name: {
-          $regex: new RegExp(`^${this.escapeRegex(normalizedName)}$`, 'i'),
-        },
-        isActive: true,
-      });
-
-      if (duplicate) {
-        throw new BadRequestException(
-          'Ya existe una categoría activa con ese nombre en este tablero',
-        );
-      }
-
+      await this.assertNoActiveDuplicateName(
+        category.tripId,
+        normalizedName,
+        category._id,
+      );
       category.name = normalizedName;
     }
 
@@ -158,6 +139,13 @@ export class CategoriesService {
       category.color = updateCategoryDto.color;
     }
     if (updateCategoryDto.isActive !== undefined) {
+      if (updateCategoryDto.isActive && !category.isActive) {
+        await this.assertNoActiveDuplicateName(
+          category.tripId,
+          category.name,
+          category._id,
+        );
+      }
       category.isActive = updateCategoryDto.isActive;
     }
 
@@ -172,6 +160,32 @@ export class CategoriesService {
     await this.categoryModel.deleteMany({
       tripId: new Types.ObjectId(boardId),
     });
+  }
+
+  private async assertNoActiveDuplicateName(
+    tripId: Types.ObjectId,
+    name: string,
+    excludeId?: Types.ObjectId,
+  ): Promise<void> {
+    const filter: Record<string, unknown> = {
+      tripId,
+      name: {
+        $regex: new RegExp(`^${this.escapeRegex(name.trim())}$`, 'i'),
+      },
+      isActive: true,
+    };
+
+    if (excludeId) {
+      filter._id = { $ne: excludeId };
+    }
+
+    const duplicate = await this.categoryModel.findOne(filter);
+
+    if (duplicate) {
+      throw new BadRequestException(
+        'Ya existe una categoría activa con ese nombre en este tablero',
+      );
+    }
   }
 
   private escapeRegex(value: string): string {

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -1,0 +1,180 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Category, CategoryDocument } from './category.schema';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { ParticipantsService } from '../participants/participants.service';
+import { resolveBoardId } from '../common/utils/resolve-board-id';
+import { DEFAULT_CATEGORIES } from './constants/default-categories';
+
+@Injectable()
+export class CategoriesService {
+  private readonly logger = new Logger(CategoriesService.name);
+
+  constructor(
+    @InjectModel(Category.name)
+    private categoryModel: Model<CategoryDocument>,
+    private participantsService: ParticipantsService,
+  ) {}
+
+  async seedDefaults(boardId: string): Promise<Category[]> {
+    const tripId = new Types.ObjectId(boardId);
+    const docs = DEFAULT_CATEGORIES.map((seed) => ({
+      tripId,
+      name: seed.name,
+      icon: seed.icon,
+      color: seed.color,
+      isActive: true,
+      isDefault: true,
+    }));
+
+    const inserted = await this.categoryModel.insertMany(docs);
+    this.logger.log(
+      `Seeded ${inserted.length} default categories for board ${boardId}`,
+    );
+    return inserted;
+  }
+
+  async create(
+    createCategoryDto: CreateCategoryDto,
+    userId: string,
+  ): Promise<Category> {
+    const boardId = resolveBoardId(createCategoryDto);
+    if (!boardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+
+    const normalizedName = createCategoryDto.name.trim();
+    const existing = await this.categoryModel.findOne({
+      tripId: new Types.ObjectId(boardId),
+      name: {
+        $regex: new RegExp(`^${this.escapeRegex(normalizedName)}$`, 'i'),
+      },
+      isActive: true,
+    });
+
+    if (existing) {
+      throw new BadRequestException(
+        'Ya existe una categoría activa con ese nombre en este tablero',
+      );
+    }
+
+    const category = new this.categoryModel({
+      tripId: new Types.ObjectId(boardId),
+      name: normalizedName,
+      icon: createCategoryDto.icon,
+      color: createCategoryDto.color,
+      isActive: true,
+      isDefault: false,
+    });
+
+    return category.save();
+  }
+
+  async findAllByBoard(
+    boardId: string,
+    userId: string,
+    includeInactive = false,
+  ): Promise<Category[]> {
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+
+    const filter: Record<string, unknown> = {
+      tripId: new Types.ObjectId(boardId),
+    };
+
+    if (!includeInactive) {
+      filter.isActive = true;
+    }
+
+    return this.categoryModel
+      .find(filter)
+      .sort({ isDefault: -1, name: 1 })
+      .lean();
+  }
+
+  async findOne(id: string, userId: string): Promise<Category> {
+    const category = await this.categoryModel.findById(id).lean();
+
+    if (!category) {
+      throw new NotFoundException('Categoría no encontrada');
+    }
+
+    await this.participantsService.ensureParticipantAccess(
+      category.tripId.toString(),
+      userId,
+    );
+
+    return category;
+  }
+
+  async update(
+    id: string,
+    updateCategoryDto: UpdateCategoryDto,
+    userId: string,
+  ): Promise<Category> {
+    const category = await this.categoryModel.findById(id);
+
+    if (!category) {
+      throw new NotFoundException('Categoría no encontrada');
+    }
+
+    await this.participantsService.ensureParticipantAccess(
+      category.tripId.toString(),
+      userId,
+    );
+
+    if (updateCategoryDto.name !== undefined) {
+      const normalizedName = updateCategoryDto.name.trim();
+      const duplicate = await this.categoryModel.findOne({
+        _id: { $ne: category._id },
+        tripId: category.tripId,
+        name: {
+          $regex: new RegExp(`^${this.escapeRegex(normalizedName)}$`, 'i'),
+        },
+        isActive: true,
+      });
+
+      if (duplicate) {
+        throw new BadRequestException(
+          'Ya existe una categoría activa con ese nombre en este tablero',
+        );
+      }
+
+      category.name = normalizedName;
+    }
+
+    if (updateCategoryDto.icon !== undefined) {
+      category.icon = updateCategoryDto.icon;
+    }
+    if (updateCategoryDto.color !== undefined) {
+      category.color = updateCategoryDto.color;
+    }
+    if (updateCategoryDto.isActive !== undefined) {
+      category.isActive = updateCategoryDto.isActive;
+    }
+
+    return category.save();
+  }
+
+  async archive(id: string, userId: string): Promise<Category> {
+    return this.update(id, { isActive: false }, userId);
+  }
+
+  async deleteByBoard(boardId: string): Promise<void> {
+    await this.categoryModel.deleteMany({
+      tripId: new Types.ObjectId(boardId),
+    });
+  }
+
+  private escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+}

--- a/src/categories/category.schema.ts
+++ b/src/categories/category.schema.ts
@@ -1,0 +1,30 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Category {
+  @Prop({ type: Types.ObjectId, ref: 'Board', required: true })
+  tripId: Types.ObjectId;
+
+  @Prop({ required: true, maxlength: 100, trim: true })
+  name: string;
+
+  @Prop({ maxlength: 50 })
+  icon?: string;
+
+  @Prop({ maxlength: 20 })
+  color?: string;
+
+  @Prop({ default: true })
+  isActive: boolean;
+
+  @Prop({ default: false })
+  isDefault: boolean;
+}
+
+export type CategoryDocument = Category & Document;
+
+export const CategorySchema = SchemaFactory.createForClass(Category);
+
+CategorySchema.index({ tripId: 1, name: 1 });
+CategorySchema.index({ tripId: 1, isActive: 1 });

--- a/src/categories/constants/default-categories.ts
+++ b/src/categories/constants/default-categories.ts
@@ -1,0 +1,17 @@
+export interface DefaultCategorySeed {
+  name: string;
+  icon?: string;
+  color?: string;
+}
+
+export const DEFAULT_CATEGORIES: DefaultCategorySeed[] = [
+  { name: 'Comida', icon: 'utensils', color: '#f97316' },
+  { name: 'Transporte', icon: 'car', color: '#3b82f6' },
+  { name: 'Hogar', icon: 'home', color: '#22c55e' },
+  { name: 'Ocio', icon: 'gamepad-2', color: '#a855f7' },
+  { name: 'Salud', icon: 'heart-pulse', color: '#ef4444' },
+  { name: 'Suscripciones', icon: 'repeat', color: '#6366f1' },
+  { name: 'Educación', icon: 'graduation-cap', color: '#14b8a6' },
+  { name: 'Ropa', icon: 'shirt', color: '#ec4899' },
+  { name: 'Otros', icon: 'ellipsis', color: '#64748b' },
+];

--- a/src/categories/dto/create-category.dto.ts
+++ b/src/categories/dto/create-category.dto.ts
@@ -1,0 +1,39 @@
+import {
+  IsNotEmpty,
+  IsString,
+  MinLength,
+  MaxLength,
+  IsOptional,
+  IsMongoId,
+  ValidateIf,
+} from 'class-validator';
+
+export class CreateCategoryDto {
+  @ValidateIf((o: CreateCategoryDto) => !o.tripId)
+  @IsNotEmpty({ message: 'boardId o tripId es requerido' })
+  @IsMongoId({ message: 'El ID del tablero no es válido' })
+  boardId?: string;
+
+  @ValidateIf((o: CreateCategoryDto) => !o.boardId)
+  @IsNotEmpty({ message: 'boardId o tripId es requerido' })
+  @IsMongoId({ message: 'El ID del tablero no es válido' })
+  tripId?: string;
+
+  @IsNotEmpty({ message: 'El nombre de la categoría es obligatorio' })
+  @IsString({ message: 'El nombre debe ser texto' })
+  @MinLength(2, { message: 'El nombre debe tener al menos 2 caracteres' })
+  @MaxLength(100, {
+    message: 'El nombre no puede tener más de 100 caracteres',
+  })
+  name: string;
+
+  @IsOptional()
+  @IsString({ message: 'El icono debe ser texto' })
+  @MaxLength(50, { message: 'El icono no puede tener más de 50 caracteres' })
+  icon?: string;
+
+  @IsOptional()
+  @IsString({ message: 'El color debe ser texto' })
+  @MaxLength(20, { message: 'El color no puede tener más de 20 caracteres' })
+  color?: string;
+}

--- a/src/categories/dto/update-category.dto.ts
+++ b/src/categories/dto/update-category.dto.ts
@@ -1,0 +1,31 @@
+import {
+  IsOptional,
+  IsString,
+  MinLength,
+  MaxLength,
+  IsBoolean,
+} from 'class-validator';
+
+export class UpdateCategoryDto {
+  @IsOptional()
+  @IsString({ message: 'El nombre debe ser texto' })
+  @MinLength(2, { message: 'El nombre debe tener al menos 2 caracteres' })
+  @MaxLength(100, {
+    message: 'El nombre no puede tener más de 100 caracteres',
+  })
+  name?: string;
+
+  @IsOptional()
+  @IsString({ message: 'El icono debe ser texto' })
+  @MaxLength(50, { message: 'El icono no puede tener más de 50 caracteres' })
+  icon?: string;
+
+  @IsOptional()
+  @IsString({ message: 'El color debe ser texto' })
+  @MaxLength(20, { message: 'El color no puede tener más de 20 caracteres' })
+  color?: string;
+
+  @IsOptional()
+  @IsBoolean({ message: 'isActive debe ser booleano' })
+  isActive?: boolean;
+}

--- a/src/trips/boards.service.spec.ts
+++ b/src/trips/boards.service.spec.ts
@@ -14,6 +14,7 @@ import {
 import { Budget } from '../budgets/budget.schema';
 import { Invitation } from '../participants/schemas/invitation.schema';
 import { Types } from 'mongoose';
+import { CategoriesService } from '../categories/categories.service';
 
 describe('BoardsService', () => {
   let service: BoardsService;
@@ -44,6 +45,11 @@ describe('BoardsService', () => {
     deleteMany: jest.fn(),
   };
 
+  const categoriesService = {
+    seedDefaults: jest.fn().mockResolvedValue([]),
+    deleteByBoard: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -57,6 +63,7 @@ describe('BoardsService', () => {
         },
         { provide: getModelToken(Budget.name), useValue: budgetModel },
         { provide: getModelToken(Invitation.name), useValue: invitationModel },
+        { provide: CategoriesService, useValue: categoriesService },
       ],
     }).compile();
 
@@ -102,6 +109,7 @@ describe('BoardsService', () => {
             provide: getModelToken(Invitation.name),
             useValue: invitationModel,
           },
+          { provide: CategoriesService, useValue: categoriesService },
         ],
       }).compile();
 
@@ -118,6 +126,9 @@ describe('BoardsService', () => {
         expect.objectContaining({
           role: ParticipantRole.OWNER,
         }),
+      );
+      expect(categoriesService.seedDefaults).toHaveBeenCalledWith(
+        boardId.toString(),
       );
       expect(result).toEqual(saved);
     });
@@ -147,6 +158,7 @@ describe('BoardsService', () => {
             provide: getModelToken(Invitation.name),
             useValue: invitationModel,
           },
+          { provide: CategoriesService, useValue: categoriesService },
         ],
       }).compile();
 

--- a/src/trips/trips.module.ts
+++ b/src/trips/trips.module.ts
@@ -9,6 +9,7 @@ import {
   Invitation,
   InvitationSchema,
 } from '../participants/schemas/invitation.schema';
+import { CategoriesModule } from '../categories/categories.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import {
       { name: Invitation.name, schema: InvitationSchema },
     ]),
     forwardRef(() => ParticipantsModule),
+    forwardRef(() => CategoriesModule),
   ],
   controllers: [BoardsController],
   providers: [BoardsService],

--- a/src/trips/trips.service.ts
+++ b/src/trips/trips.service.ts
@@ -5,6 +5,8 @@ import {
   OnModuleInit,
   Logger,
   BadRequestException,
+  Inject,
+  forwardRef,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
@@ -22,6 +24,7 @@ import {
 import { CreateBoardDto } from './dto/create-board.dto';
 import { UpdateBoardDto } from './dto/update-board.dto';
 import { DEFAULT_CURRENCY } from '../common/constants/currencies';
+import { CategoriesService } from '../categories/categories.service';
 
 @Injectable()
 export class BoardsService implements OnModuleInit {
@@ -34,6 +37,8 @@ export class BoardsService implements OnModuleInit {
     @InjectModel(Budget.name) private budgetModel: Model<BudgetDocument>,
     @InjectModel(Invitation.name)
     private invitationModel: Model<InvitationDocument>,
+    @Inject(forwardRef(() => CategoriesService))
+    private categoriesService: CategoriesService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -63,6 +68,8 @@ export class BoardsService implements OnModuleInit {
       userId: new Types.ObjectId(userId),
       role: ParticipantRole.OWNER,
     });
+
+    await this.categoriesService.seedDefaults(savedBoard._id.toString());
 
     return savedBoard;
   }
@@ -223,6 +230,7 @@ export class BoardsService implements OnModuleInit {
     const boardId = new Types.ObjectId(id);
 
     await this.budgetModel.deleteMany({ tripId: boardId });
+    await this.categoriesService.deleteByBoard(id);
     await this.participantModel.deleteMany({ tripId: boardId });
     await this.invitationModel.deleteMany({ tripId: boardId });
     await this.boardModel.findByIdAndDelete(id);


### PR DESCRIPTION
## Summary

- Nuevo módulo `Categories` con CRUD autenticado scoped a `boardId` (alias `tripId`).
- Seed automático de 9 categorías default al crear un tablero (Comida, Transporte, Hogar, etc.).
- Archivado soft-delete vía `DELETE /api/categories/:id` (`isActive: false`) sin borrar historial.
- Limpieza de categorías al eliminar un board.

Closes #3

## Criterios de aceptación

- [x] CRUD autenticado de categorías de un board (solo miembros)
- [x] Al crear board se insertan categorías default
- [x] Archivar/desactivar categoría sin borrar historial de gastos
- [x] Tests de seed y acceso documentados

## Cómo probarlo

1. Levantar Mongo y el backend: `npm run start:dev`
2. Autenticarse y crear un board (`POST /api/boards` con `type: everyday` o `travel`)
3. `GET /api/categories?boardId=<id>` → debe listar 9 categorías default
4. `POST /api/categories` con `{ boardId, name: "Mascotas" }` → crea categoría custom
5. `PATCH /api/categories/:id` → editar nombre/icono/color
6. `DELETE /api/categories/:id` → archiva (`isActive: false`); con `?includeInactive=true` sigue visible
7. Con otro usuario no miembro del board → `403 Forbidden`
8. `npm run test` → incluye specs de seed y acceso

## Requiere antes de deploy

Ninguno (sin migraciones ni env vars nuevas).

## Notas para el reviewer

- El campo Mongo sigue siendo `tripId` (legacy del rename Board/Trip) para consistencia con el resto del schema.
- `categoryId` en Expense queda para el issue de expenses (#5); este PR no toca expenses.
- Duplicados de nombre se validan case-insensitive solo entre categorías activas.