### PR TITLE
[Issue #4] Medios de pago user|board (cash/debit/credit + closingDay)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { ExpensesModule } from './expenses/expenses.module';
 import { BotModule } from './bot/bot.module';
 import { CardsModule } from './cards/cards.module';
 import { CategoriesModule } from './categories/categories.module';
+import { PaymentMethodsModule } from './payment-methods/payment-methods.module';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { CategoriesModule } from './categories/categories.module';
     BotModule,
     CardsModule,
     CategoriesModule,
+    PaymentMethodsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/cards/cards.module.ts
+++ b/src/cards/cards.module.ts
@@ -1,15 +1,10 @@
-import { Module } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
+import { Module, forwardRef } from '@nestjs/common';
 import { CardsService } from './cards.service';
 import { CardsController } from './cards.controller';
-import { Card, CardSchema } from './card.schema';
-import { ParticipantsModule } from '../participants/participants.module';
+import { PaymentMethodsModule } from '../payment-methods/payment-methods.module';
 
 @Module({
-  imports: [
-    MongooseModule.forFeature([{ name: Card.name, schema: CardSchema }]),
-    ParticipantsModule,
-  ],
+  imports: [forwardRef(() => PaymentMethodsModule)],
   controllers: [CardsController],
   providers: [CardsService],
   exports: [CardsService],

--- a/src/cards/cards.service.spec.ts
+++ b/src/cards/cards.service.spec.ts
@@ -1,0 +1,49 @@
+import { Types } from 'mongoose';
+import { CardType } from './card.schema';
+import {
+  PaymentMethod,
+  PaymentMethodKind,
+  PaymentMethodOwnerType,
+} from '../payment-methods/payment-method.schema';
+import { CardsService } from './cards.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+
+describe('CardsService', () => {
+  const paymentMethodsService = {
+    findAvailableForBoard: jest.fn(),
+  };
+
+  let service: CardsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new CardsService(
+      paymentMethodsService as unknown as PaymentMethodsService,
+    );
+  });
+
+  it('should map board-owned payment methods without userId', async () => {
+    const boardId = new Types.ObjectId();
+    const methodId = new Types.ObjectId();
+
+    paymentMethodsService.findAvailableForBoard.mockResolvedValue([
+      {
+        _id: methodId,
+        ownerType: PaymentMethodOwnerType.BOARD,
+        kind: PaymentMethodKind.CREDIT,
+        tripId: boardId,
+        name: 'Visa compartida',
+        lastFourDigits: '4242',
+        brand: CardType.VISA,
+        isActive: true,
+      } as PaymentMethod,
+    ]);
+
+    const cards = await service.findByTrip(boardId.toString(), 'user-1');
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].type).toBe(CardType.VISA);
+    expect(cards[0].userId).toBeUndefined();
+    expect(cards[0].tripId?.toString()).toBe(boardId.toString());
+  });
+});

--- a/src/cards/cards.service.ts
+++ b/src/cards/cards.service.ts
@@ -1,157 +1,69 @@
-import {
-  Injectable,
-  NotFoundException,
-  BadRequestException,
-  Logger,
-} from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model, Types } from 'mongoose';
-import { Card, CardDocument } from './card.schema';
+import { Injectable, Logger } from '@nestjs/common';
+import { Card, CardType } from './card.schema';
 import { CreateCardDto } from './dto/create-card.dto';
 import { UpdateCardDto } from './dto/update-card.dto';
-import { ParticipantsService } from '../participants/participants.service';
-import { UserDocument } from '../users/user.schema';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+import {
+  PaymentMethod,
+  PaymentMethodKind,
+  PaymentMethodOwnerType,
+} from '../payment-methods/payment-method.schema';
 
 @Injectable()
 export class CardsService {
   private readonly logger = new Logger(CardsService.name);
 
-  constructor(
-    @InjectModel(Card.name) private cardModel: Model<CardDocument>,
-    private participantsService: ParticipantsService,
-  ) {}
-
-  private extractUserId(
-    cardUserId: Types.ObjectId | UserDocument | string,
-  ): string {
-    if (cardUserId instanceof Types.ObjectId) {
-      return cardUserId.toString();
-    }
-    if (typeof cardUserId === 'object' && cardUserId !== null) {
-      if ('_id' in cardUserId && cardUserId._id) {
-        return cardUserId._id.toString();
-      }
-      throw new Error('Invalid userId format: object without _id');
-    }
-    if (typeof cardUserId === 'string') {
-      return cardUserId;
-    }
-    throw new Error('Invalid userId format');
-  }
+  constructor(private paymentMethodsService: PaymentMethodsService) {}
 
   async create(createCardDto: CreateCardDto, userId: string): Promise<Card> {
-    if (createCardDto.tripId) {
-      await this.participantsService.ensureParticipantAccess(
-        createCardDto.tripId,
-        userId,
-      );
-    }
-
-    const card = new this.cardModel({
-      ...createCardDto,
-      userId: new Types.ObjectId(userId),
-      tripId: createCardDto.tripId
-        ? new Types.ObjectId(createCardDto.tripId)
-        : null,
-    });
-
-    const savedCard = await card.save();
-    this.logger.log(
-      `Tarjeta creada: ${savedCard.name} (****${savedCard.lastFourDigits})`,
+    const paymentMethod = await this.paymentMethodsService.create(
+      {
+        ownerType: PaymentMethodOwnerType.USER,
+        kind: PaymentMethodKind.CREDIT,
+        tripId: createCardDto.tripId,
+        name: createCardDto.name,
+        lastFourDigits: createCardDto.lastFourDigits,
+        brand: createCardDto.type ?? CardType.OTHER,
+      },
+      userId,
     );
 
-    return savedCard;
+    this.logger.log(
+      `Tarjeta creada: ${paymentMethod.name} (****${paymentMethod.lastFourDigits})`,
+    );
+
+    return this.toLegacyCard(paymentMethod);
   }
 
   async findByUser(userId: string): Promise<Card[]> {
-    return this.cardModel
-      .find({
-        userId: new Types.ObjectId(userId),
-        isActive: true,
-      })
-      .populate('tripId', 'name')
-      .sort({ createdAt: -1 })
-      .lean();
+    const methods = await this.paymentMethodsService.findByUser(userId);
+    return methods
+      .filter(
+        (m) =>
+          m.kind === PaymentMethodKind.CREDIT ||
+          m.kind === PaymentMethodKind.DEBIT,
+      )
+      .map((m) => this.toLegacyCard(m));
   }
 
   async findByTrip(tripId: string, userId: string): Promise<Card[]> {
-    await this.participantsService.ensureParticipantAccess(tripId, userId);
-
-    const participants = await this.participantsService.findByTrip(
+    const methods = await this.paymentMethodsService.findAvailableForBoard(
       tripId,
       userId,
     );
 
-    const participantUserIds: Types.ObjectId[] = [];
-    for (const p of participants) {
-      if (!p.userId) {
-        continue;
-      }
-
-      if (p.userId instanceof Types.ObjectId) {
-        participantUserIds.push(p.userId);
-      } else if (typeof p.userId === 'object' && p.userId !== null) {
-        const userDoc = p.userId as UserDocument;
-        if ('_id' in userDoc && userDoc._id) {
-          participantUserIds.push(new Types.ObjectId(userDoc._id.toString()));
-        } else if ('id' in userDoc && userDoc.id) {
-          const idValue = userDoc.id;
-          if (idValue instanceof Types.ObjectId) {
-            participantUserIds.push(idValue);
-          } else if (
-            typeof idValue === 'string' ||
-            typeof idValue === 'number'
-          ) {
-            participantUserIds.push(new Types.ObjectId(String(idValue)));
-          }
-        }
-      } else {
-        try {
-          const userIdStr = String(p.userId);
-          participantUserIds.push(new Types.ObjectId(userIdStr));
-        } catch {
-          continue;
-        }
-      }
-    }
-
-    return this.cardModel
-      .find({
-        $or: [
-          { tripId: new Types.ObjectId(tripId), isActive: true },
-          {
-            userId: { $in: participantUserIds },
-            $or: [
-              { tripId: { $exists: false } },
-              { tripId: null },
-              { tripId: new Types.ObjectId(tripId) },
-            ],
-            isActive: true,
-          },
-        ],
-      })
-      .populate('userId', 'firstName lastName')
-      .populate('tripId', 'name')
-      .sort({ createdAt: -1 })
-      .lean();
+    return methods
+      .filter(
+        (m) =>
+          m.kind === PaymentMethodKind.CREDIT ||
+          m.kind === PaymentMethodKind.DEBIT,
+      )
+      .map((m) => this.toLegacyCard(m));
   }
 
   async findOne(id: string, userId: string): Promise<Card> {
-    const card = await this.cardModel.findById(id).lean();
-
-    if (!card) {
-      throw new NotFoundException('Tarjeta no encontrada');
-    }
-
-    const cardUserId = this.extractUserId(card.userId);
-
-    if (cardUserId !== String(userId)) {
-      throw new BadRequestException(
-        'No tienes permiso para acceder a esta tarjeta',
-      );
-    }
-
-    return card;
+    const paymentMethod = await this.paymentMethodsService.findOne(id, userId);
+    return this.toLegacyCard(paymentMethod);
   }
 
   async update(
@@ -159,65 +71,48 @@ export class CardsService {
     updateCardDto: UpdateCardDto,
     userId: string,
   ): Promise<Card> {
-    const card = await this.cardModel.findById(id);
-
-    if (!card) {
-      throw new NotFoundException('Tarjeta no encontrada');
-    }
-
-    const cardUserId = this.extractUserId(card.userId);
-
-    if (cardUserId !== String(userId)) {
-      throw new BadRequestException(
-        'No tienes permiso para modificar esta tarjeta',
-      );
-    }
-
-    if (updateCardDto.tripId) {
-      await this.participantsService.ensureParticipantAccess(
-        updateCardDto.tripId,
-        userId,
-      );
-      card.tripId = new Types.ObjectId(updateCardDto.tripId);
-    }
-
-    if (updateCardDto.name !== undefined) {
-      card.name = updateCardDto.name;
-    }
-    if (updateCardDto.lastFourDigits !== undefined) {
-      card.lastFourDigits = updateCardDto.lastFourDigits;
-    }
-    if (updateCardDto.type !== undefined) {
-      card.type = updateCardDto.type;
-    }
-    if (updateCardDto.isActive !== undefined) {
-      card.isActive = updateCardDto.isActive;
-    }
-
-    const savedCard = await card.save();
-    this.logger.log(
-      `Tarjeta actualizada: ${savedCard.name} (****${savedCard.lastFourDigits})`,
+    const paymentMethod = await this.paymentMethodsService.update(
+      id,
+      {
+        name: updateCardDto.name,
+        lastFourDigits: updateCardDto.lastFourDigits,
+        brand: updateCardDto.type,
+        isActive: updateCardDto.isActive,
+      },
+      userId,
     );
 
-    return savedCard;
+    this.logger.log(
+      `Tarjeta actualizada: ${paymentMethod.name} (****${paymentMethod.lastFourDigits})`,
+    );
+
+    return this.toLegacyCard(paymentMethod);
   }
 
   async remove(id: string, userId: string): Promise<void> {
-    const card = await this.cardModel.findById(id);
+    const paymentMethod = await this.paymentMethodsService.findOne(id, userId);
+    await this.paymentMethodsService.archive(id, userId);
+    this.logger.log(`Tarjeta eliminada: ${paymentMethod.name}`);
+  }
 
-    if (!card) {
-      throw new NotFoundException('Tarjeta no encontrada');
-    }
+  private toLegacyCard(paymentMethod: PaymentMethod): Card {
+    const brand = paymentMethod.brand;
+    const type =
+      brand === CardType.VISA ||
+      brand === CardType.MASTERCARD ||
+      brand === CardType.AMEX ||
+      brand === CardType.OTHER
+        ? brand
+        : CardType.OTHER;
 
-    const cardUserId = this.extractUserId(card.userId);
-
-    if (cardUserId !== String(userId)) {
-      throw new BadRequestException(
-        'No tienes permiso para eliminar esta tarjeta',
-      );
-    }
-
-    await this.cardModel.findByIdAndDelete(id);
-    this.logger.log(`Tarjeta eliminada: ${card.name}`);
+    return {
+      ...paymentMethod,
+      userId: paymentMethod.userId!,
+      tripId: paymentMethod.tripId,
+      name: paymentMethod.name,
+      lastFourDigits: paymentMethod.lastFourDigits ?? '0000',
+      type,
+      isActive: paymentMethod.isActive,
+    } as Card;
   }
 }

--- a/src/cards/cards.service.ts
+++ b/src/cards/cards.service.ts
@@ -8,6 +8,7 @@ import {
   PaymentMethodKind,
   PaymentMethodOwnerType,
 } from '../payment-methods/payment-method.schema';
+import { resolveCardTypeFromBrand } from '../common/utils/card-type-from-brand';
 
 @Injectable()
 export class CardsService {
@@ -96,23 +97,21 @@ export class CardsService {
   }
 
   private toLegacyCard(paymentMethod: PaymentMethod): Card {
-    const brand = paymentMethod.brand;
-    const type =
-      brand === CardType.VISA ||
-      brand === CardType.MASTERCARD ||
-      brand === CardType.AMEX ||
-      brand === CardType.OTHER
-        ? brand
-        : CardType.OTHER;
+    const type = resolveCardTypeFromBrand(paymentMethod.brand);
 
-    return {
+    const legacy: Record<string, unknown> = {
       ...paymentMethod,
-      userId: paymentMethod.userId!,
-      tripId: paymentMethod.tripId,
       name: paymentMethod.name,
       lastFourDigits: paymentMethod.lastFourDigits ?? '0000',
       type,
       isActive: paymentMethod.isActive,
-    } as Card;
+      tripId: paymentMethod.tripId,
+    };
+
+    if (paymentMethod.userId) {
+      legacy.userId = paymentMethod.userId;
+    }
+
+    return legacy as unknown as Card;
   }
 }

--- a/src/common/utils/card-type-from-brand.spec.ts
+++ b/src/common/utils/card-type-from-brand.spec.ts
@@ -1,0 +1,18 @@
+import { CardType } from '../../cards/card.schema';
+import { resolveCardTypeFromBrand } from './card-type-from-brand';
+
+describe('resolveCardTypeFromBrand', () => {
+  it('should prefer legacy type when present', () => {
+    expect(resolveCardTypeFromBrand('visa', CardType.MASTERCARD)).toBe(
+      CardType.MASTERCARD,
+    );
+  });
+
+  it('should map brand to card type', () => {
+    expect(resolveCardTypeFromBrand(CardType.VISA)).toBe(CardType.VISA);
+  });
+
+  it('should default unknown brands to other', () => {
+    expect(resolveCardTypeFromBrand('unknown-network')).toBe(CardType.OTHER);
+  });
+});

--- a/src/common/utils/card-type-from-brand.ts
+++ b/src/common/utils/card-type-from-brand.ts
@@ -1,0 +1,18 @@
+import { CardType } from '../../cards/card.schema';
+
+/** Maps PaymentMethod.brand (or legacy type) to CardType for API responses. */
+export function resolveCardTypeFromBrand(
+  brand?: string,
+  legacyType?: string,
+): CardType {
+  const candidate = legacyType ?? brand;
+  if (
+    candidate === CardType.VISA ||
+    candidate === CardType.MASTERCARD ||
+    candidate === CardType.AMEX ||
+    candidate === CardType.OTHER
+  ) {
+    return candidate;
+  }
+  return CardType.OTHER;
+}

--- a/src/expenses/expense.schema.ts
+++ b/src/expenses/expense.schema.ts
@@ -67,7 +67,7 @@ export class Expense {
   })
   paymentMethod: PaymentMethod;
 
-  @Prop({ type: Types.ObjectId, ref: 'Card', required: false })
+  @Prop({ type: Types.ObjectId, ref: 'PaymentMethod', required: false })
   cardId?: Types.ObjectId;
 
   @Prop({ type: Boolean, default: false, required: true })

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -24,6 +24,7 @@ import { CreateExpenseDto } from './dto/create-expense.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
 import { DEFAULT_CURRENCY } from '../common/constants/currencies';
 import { resolveBoardId } from '../common/utils/resolve-board-id';
+import { resolveCardTypeFromBrand } from '../common/utils/card-type-from-brand';
 import { BoardsService } from '../trips/trips.service';
 
 interface PopulatedUser {
@@ -49,7 +50,8 @@ interface PopulatedCard {
   _id: Types.ObjectId;
   name: string;
   lastFourDigits: string;
-  type: string;
+  type?: string;
+  brand?: string;
   userId?: PopulatedUser | Types.ObjectId;
 }
 
@@ -370,7 +372,7 @@ export class ExpensesService {
       .populate('budgetId', '_id name')
       .populate({
         path: 'cardId',
-        select: '_id name lastFourDigits type',
+        select: '_id name lastFourDigits brand type userId',
         populate: {
           path: 'userId',
           select: 'firstName lastName',
@@ -426,7 +428,7 @@ export class ExpensesService {
       .populate('budgetId', '_id name')
       .populate({
         path: 'cardId',
-        select: '_id name lastFourDigits type',
+        select: '_id name lastFourDigits brand type userId',
         populate: {
           path: 'userId',
           select: 'firstName lastName',
@@ -461,7 +463,7 @@ export class ExpensesService {
       .populate('budgetId', '_id name')
       .populate({
         path: 'cardId',
-        select: '_id name lastFourDigits type',
+        select: '_id name lastFourDigits brand type userId',
         populate: {
           path: 'userId',
           select: 'firstName lastName',
@@ -756,7 +758,7 @@ export class ExpensesService {
       .populate('budgetId', '_id name')
       .populate({
         path: 'cardId',
-        select: '_id name lastFourDigits type',
+        select: '_id name lastFourDigits brand type userId',
         populate: {
           path: 'userId',
           select: 'firstName lastName',
@@ -1277,7 +1279,7 @@ export class ExpensesService {
       .populate('budgetId', '_id name')
       .populate({
         path: 'cardId',
-        select: '_id name lastFourDigits type',
+        select: '_id name lastFourDigits brand type userId',
         populate: {
           path: 'userId',
           select: 'firstName lastName',
@@ -1392,7 +1394,7 @@ export class ExpensesService {
           _id: objectIdToString(card._id),
           name: card.name,
           lastFourDigits: card.lastFourDigits,
-          type: card.type,
+          type: resolveCardTypeFromBrand(card.brand, card.type),
         };
 
         if (card.userId) {

--- a/src/payment-methods/dto/create-payment-method.dto.ts
+++ b/src/payment-methods/dto/create-payment-method.dto.ts
@@ -1,0 +1,87 @@
+import {
+  IsEnum,
+  IsMongoId,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+  Matches,
+  ValidateIf,
+} from 'class-validator';
+import {
+  PaymentMethodKind,
+  PaymentMethodOwnerType,
+} from '../payment-method.schema';
+
+export class CreatePaymentMethodDto {
+  @IsEnum(PaymentMethodOwnerType, {
+    message: 'ownerType debe ser user o board',
+  })
+  ownerType: PaymentMethodOwnerType;
+
+  @IsEnum(PaymentMethodKind, {
+    message: 'kind debe ser cash, debit o credit',
+  })
+  kind: PaymentMethodKind;
+
+  @ValidateIf(
+    (o: CreatePaymentMethodDto) =>
+      o.ownerType === PaymentMethodOwnerType.BOARD && !o.tripId,
+  )
+  @IsNotEmpty({
+    message: 'boardId o tripId es requerido para métodos del tablero',
+  })
+  @IsMongoId({ message: 'El ID del tablero no es válido' })
+  boardId?: string;
+
+  @ValidateIf(
+    (o: CreatePaymentMethodDto) =>
+      o.ownerType === PaymentMethodOwnerType.BOARD && !o.boardId,
+  )
+  @IsNotEmpty({
+    message: 'boardId o tripId es requerido para métodos del tablero',
+  })
+  @IsMongoId({ message: 'El ID del tablero no es válido' })
+  tripId?: string;
+
+  @IsNotEmpty({ message: 'El nombre es obligatorio' })
+  @IsString({ message: 'El nombre debe ser texto' })
+  @MinLength(2, { message: 'El nombre debe tener al menos 2 caracteres' })
+  @MaxLength(100, {
+    message: 'El nombre no puede tener más de 100 caracteres',
+  })
+  name: string;
+
+  @ValidateIf(
+    (o: CreatePaymentMethodDto) =>
+      o.kind === PaymentMethodKind.DEBIT || o.kind === PaymentMethodKind.CREDIT,
+  )
+  @IsNotEmpty({
+    message: 'Los últimos 4 dígitos son obligatorios para débito y crédito',
+  })
+  @IsString({ message: 'Los últimos 4 dígitos deben ser texto' })
+  @MinLength(4, { message: 'Debe tener exactamente 4 dígitos' })
+  @MaxLength(4, { message: 'Debe tener exactamente 4 dígitos' })
+  @Matches(/^\d{4}$/, {
+    message: 'Los últimos 4 dígitos deben ser números',
+  })
+  lastFourDigits?: string;
+
+  @IsOptional()
+  @IsString({ message: 'La marca debe ser texto' })
+  @MaxLength(50, { message: 'La marca no puede tener más de 50 caracteres' })
+  brand?: string;
+
+  @IsOptional()
+  @Min(1, { message: 'closingDay debe estar entre 1 y 28' })
+  @Max(28, { message: 'closingDay debe estar entre 1 y 28' })
+  closingDay?: number;
+
+  @IsOptional()
+  @Min(1, { message: 'dueDay debe estar entre 1 y 28' })
+  @Max(28, { message: 'dueDay debe estar entre 1 y 28' })
+  dueDay?: number;
+}

--- a/src/payment-methods/dto/update-payment-method.dto.ts
+++ b/src/payment-methods/dto/update-payment-method.dto.ts
@@ -1,0 +1,48 @@
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+  Matches,
+} from 'class-validator';
+
+export class UpdatePaymentMethodDto {
+  @IsOptional()
+  @IsString({ message: 'El nombre debe ser texto' })
+  @MinLength(2, { message: 'El nombre debe tener al menos 2 caracteres' })
+  @MaxLength(100, {
+    message: 'El nombre no puede tener más de 100 caracteres',
+  })
+  name?: string;
+
+  @IsOptional()
+  @IsString({ message: 'Los últimos 4 dígitos deben ser texto' })
+  @MinLength(4, { message: 'Debe tener exactamente 4 dígitos' })
+  @MaxLength(4, { message: 'Debe tener exactamente 4 dígitos' })
+  @Matches(/^\d{4}$/, {
+    message: 'Los últimos 4 dígitos deben ser números',
+  })
+  lastFourDigits?: string;
+
+  @IsOptional()
+  @IsString({ message: 'La marca debe ser texto' })
+  @MaxLength(50, { message: 'La marca no puede tener más de 50 caracteres' })
+  brand?: string;
+
+  @IsOptional()
+  @Min(1, { message: 'closingDay debe estar entre 1 y 28' })
+  @Max(28, { message: 'closingDay debe estar entre 1 y 28' })
+  closingDay?: number;
+
+  @IsOptional()
+  @Min(1, { message: 'dueDay debe estar entre 1 y 28' })
+  @Max(28, { message: 'dueDay debe estar entre 1 y 28' })
+  dueDay?: number;
+
+  @IsOptional()
+  @IsBoolean({ message: 'isActive debe ser booleano' })
+  isActive?: boolean;
+}

--- a/src/payment-methods/payment-method.schema.ts
+++ b/src/payment-methods/payment-method.schema.ts
@@ -1,0 +1,65 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export enum PaymentMethodOwnerType {
+  USER = 'user',
+  BOARD = 'board',
+}
+
+export enum PaymentMethodKind {
+  CASH = 'cash',
+  DEBIT = 'debit',
+  CREDIT = 'credit',
+}
+
+@Schema({ timestamps: true, collection: 'paymentmethods' })
+export class PaymentMethod {
+  @Prop({
+    type: String,
+    enum: PaymentMethodOwnerType,
+    required: true,
+  })
+  ownerType: PaymentMethodOwnerType;
+
+  @Prop({
+    type: String,
+    enum: PaymentMethodKind,
+    required: true,
+  })
+  kind: PaymentMethodKind;
+
+  @Prop({ type: Types.ObjectId, ref: 'User' })
+  userId?: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: 'Board' })
+  tripId?: Types.ObjectId;
+
+  @Prop({ required: true, maxlength: 100, trim: true })
+  name: string;
+
+  @Prop({ minlength: 4, maxlength: 4 })
+  lastFourDigits?: string;
+
+  @Prop({ maxlength: 50 })
+  brand?: string;
+
+  @Prop({ min: 1, max: 28 })
+  closingDay?: number;
+
+  @Prop({ min: 1, max: 28 })
+  dueDay?: number;
+
+  @Prop({ default: true })
+  isActive: boolean;
+
+  @Prop({ type: Types.ObjectId })
+  migratedFromCardId?: Types.ObjectId;
+}
+
+export type PaymentMethodDocument = PaymentMethod & Document;
+
+export const PaymentMethodSchema = SchemaFactory.createForClass(PaymentMethod);
+
+PaymentMethodSchema.index({ ownerType: 1, userId: 1, isActive: 1 });
+PaymentMethodSchema.index({ ownerType: 1, tripId: 1, isActive: 1 });
+PaymentMethodSchema.index({ migratedFromCardId: 1 });

--- a/src/payment-methods/payment-methods.controller.ts
+++ b/src/payment-methods/payment-methods.controller.ts
@@ -1,0 +1,125 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+  Query,
+} from '@nestjs/common';
+import { PaymentMethodsService } from './payment-methods.service';
+import { CreatePaymentMethodDto } from './dto/create-payment-method.dto';
+import { UpdatePaymentMethodDto } from './dto/update-payment-method.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GetUser } from '../auth/decorators/get-user.decorator';
+import { UserDocument } from '../users/user.schema';
+
+@Controller('payment-methods')
+@UseGuards(JwtAuthGuard)
+export class PaymentMethodsController {
+  constructor(private readonly paymentMethodsService: PaymentMethodsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Body() createDto: CreatePaymentMethodDto,
+    @GetUser() user: UserDocument,
+  ) {
+    const paymentMethod = await this.paymentMethodsService.create(
+      createDto,
+      user._id.toString(),
+    );
+    return {
+      message: 'Medio de pago creado exitosamente',
+      paymentMethod,
+    };
+  }
+
+  @Get()
+  async list(
+    @GetUser() user: UserDocument,
+    @Query('boardId') boardId?: string,
+    @Query('tripId') tripId?: string,
+    @Query('scope') scope?: string,
+    @Query('includeInactive') includeInactive?: string,
+  ) {
+    const resolvedBoardId = boardId || tripId;
+    const inactive = includeInactive === 'true';
+
+    if (scope === 'user') {
+      const paymentMethods = await this.paymentMethodsService.findByUser(
+        user._id.toString(),
+        inactive,
+      );
+      return { paymentMethods };
+    }
+
+    if (scope === 'board' && resolvedBoardId) {
+      const paymentMethods = await this.paymentMethodsService.findBoardOwned(
+        resolvedBoardId,
+        user._id.toString(),
+        inactive,
+      );
+      return { paymentMethods };
+    }
+
+    if (resolvedBoardId) {
+      const paymentMethods =
+        await this.paymentMethodsService.findAvailableForBoard(
+          resolvedBoardId,
+          user._id.toString(),
+          inactive,
+        );
+      return { paymentMethods };
+    }
+
+    const paymentMethods = await this.paymentMethodsService.findByUser(
+      user._id.toString(),
+      inactive,
+    );
+    return { paymentMethods };
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string, @GetUser() user: UserDocument) {
+    const paymentMethod = await this.paymentMethodsService.findOne(
+      id,
+      user._id.toString(),
+    );
+    return { paymentMethod };
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() updateDto: UpdatePaymentMethodDto,
+    @GetUser() user: UserDocument,
+  ) {
+    const paymentMethod = await this.paymentMethodsService.update(
+      id,
+      updateDto,
+      user._id.toString(),
+    );
+    return {
+      message: 'Medio de pago actualizado exitosamente',
+      paymentMethod,
+    };
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  async archive(@Param('id') id: string, @GetUser() user: UserDocument) {
+    const paymentMethod = await this.paymentMethodsService.archive(
+      id,
+      user._id.toString(),
+    );
+    return {
+      message: 'Medio de pago archivado exitosamente',
+      paymentMethod,
+    };
+  }
+}

--- a/src/payment-methods/payment-methods.module.ts
+++ b/src/payment-methods/payment-methods.module.ts
@@ -1,0 +1,21 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { PaymentMethodsService } from './payment-methods.service';
+import { PaymentMethodsController } from './payment-methods.controller';
+import { PaymentMethod, PaymentMethodSchema } from './payment-method.schema';
+import { ParticipantsModule } from '../participants/participants.module';
+import { Card, CardSchema } from '../cards/card.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: PaymentMethod.name, schema: PaymentMethodSchema },
+      { name: Card.name, schema: CardSchema },
+    ]),
+    forwardRef(() => ParticipantsModule),
+  ],
+  controllers: [PaymentMethodsController],
+  providers: [PaymentMethodsService],
+  exports: [PaymentMethodsService, MongooseModule],
+})
+export class PaymentMethodsModule {}

--- a/src/payment-methods/payment-methods.service.spec.ts
+++ b/src/payment-methods/payment-methods.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { Types } from 'mongoose';
+import { PaymentMethodsService } from './payment-methods.service';
+import {
+  PaymentMethod,
+  PaymentMethodKind,
+  PaymentMethodOwnerType,
+} from './payment-method.schema';
+import { Card } from '../cards/card.schema';
+import { ParticipantsService } from '../participants/participants.service';
+
+describe('PaymentMethodsService', () => {
+  let service: PaymentMethodsService;
+
+  const boardId = new Types.ObjectId();
+  const userId = new Types.ObjectId().toString();
+  const otherUserId = new Types.ObjectId().toString();
+  const methodId = new Types.ObjectId();
+
+  const modelMethods = {
+    find: jest.fn(),
+    findById: jest.fn(),
+    findOne: jest.fn(),
+    deleteMany: jest.fn(),
+  };
+
+  const paymentMethodModel = jest
+    .fn()
+    .mockImplementation((data: Record<string, unknown>) => ({
+      ...data,
+      save: jest.fn().mockResolvedValue({ ...data, _id: methodId }),
+    }));
+  Object.assign(paymentMethodModel, modelMethods);
+
+  const cardModel = {
+    find: jest.fn().mockResolvedValue([]),
+  };
+
+  const participantsService = {
+    ensureParticipantAccess: jest.fn(),
+    findByTrip: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    cardModel.find.mockResolvedValue([]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentMethodsService,
+        {
+          provide: getModelToken(PaymentMethod.name),
+          useValue: paymentMethodModel,
+        },
+        { provide: getModelToken(Card.name), useValue: cardModel },
+        { provide: ParticipantsService, useValue: participantsService },
+      ],
+    }).compile();
+
+    service = module.get(PaymentMethodsService);
+  });
+
+  describe('create', () => {
+    it('should create user-owned credit with closingDay', async () => {
+      const result = await service.create(
+        {
+          ownerType: PaymentMethodOwnerType.USER,
+          kind: PaymentMethodKind.CREDIT,
+          name: 'Visa',
+          lastFourDigits: '4242',
+          closingDay: 14,
+        },
+        userId,
+      );
+
+      expect(result.closingDay).toBe(14);
+      expect(result.kind).toBe(PaymentMethodKind.CREDIT);
+    });
+
+    it('should reject closingDay above 28', async () => {
+      await expect(
+        service.create(
+          {
+            ownerType: PaymentMethodOwnerType.USER,
+            kind: PaymentMethodKind.CREDIT,
+            name: 'Visa',
+            lastFourDigits: '4242',
+            closingDay: 31,
+          },
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should create board-owned cash for members', async () => {
+      participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+
+      const result = await service.create(
+        {
+          ownerType: PaymentMethodOwnerType.BOARD,
+          boardId: boardId.toString(),
+          kind: PaymentMethodKind.CASH,
+          name: 'Efectivo hogar',
+        },
+        userId,
+      );
+
+      expect(result.ownerType).toBe(PaymentMethodOwnerType.BOARD);
+      expect(result.kind).toBe(PaymentMethodKind.CASH);
+      expect(participantsService.ensureParticipantAccess).toHaveBeenCalled();
+    });
+  });
+
+  describe('findAvailableForBoard', () => {
+    it('should require participant access', async () => {
+      participantsService.ensureParticipantAccess.mockRejectedValue(
+        new ForbiddenException('No tienes acceso'),
+      );
+
+      await expect(
+        service.findAvailableForBoard(boardId.toString(), otherUserId),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('should return board-owned and participant user-owned methods', async () => {
+      participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+      participantsService.findByTrip.mockResolvedValue([
+        { userId: new Types.ObjectId(userId) },
+      ]);
+
+      const chain = {
+        populate: jest.fn().mockReturnThis(),
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([
+          {
+            _id: methodId,
+            ownerType: PaymentMethodOwnerType.BOARD,
+            kind: PaymentMethodKind.CASH,
+            name: 'Efectivo',
+          },
+        ]),
+      };
+      modelMethods.find.mockReturnValue(chain);
+
+      const result = await service.findAvailableForBoard(
+        boardId.toString(),
+        userId,
+      );
+
+      expect(modelMethods.find).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/src/payment-methods/payment-methods.service.ts
+++ b/src/payment-methods/payment-methods.service.ts
@@ -1,0 +1,373 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+  OnModuleInit,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import {
+  PaymentMethod,
+  PaymentMethodDocument,
+  PaymentMethodKind,
+  PaymentMethodOwnerType,
+} from './payment-method.schema';
+import { CreatePaymentMethodDto } from './dto/create-payment-method.dto';
+import { UpdatePaymentMethodDto } from './dto/update-payment-method.dto';
+import { ParticipantsService } from '../participants/participants.service';
+import { resolveBoardId } from '../common/utils/resolve-board-id';
+import { Card, CardDocument } from '../cards/card.schema';
+import { UserDocument } from '../users/user.schema';
+
+@Injectable()
+export class PaymentMethodsService implements OnModuleInit {
+  private readonly logger = new Logger(PaymentMethodsService.name);
+
+  constructor(
+    @InjectModel(PaymentMethod.name)
+    private paymentMethodModel: Model<PaymentMethodDocument>,
+    @InjectModel(Card.name)
+    private cardModel: Model<CardDocument>,
+    private participantsService: ParticipantsService,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    const cards = await this.cardModel.find().lean();
+    let migrated = 0;
+
+    for (const card of cards) {
+      const existing = await this.paymentMethodModel.findOne({
+        migratedFromCardId: card._id,
+      });
+
+      if (existing) {
+        continue;
+      }
+
+      const byId = await this.paymentMethodModel.findById(card._id);
+      if (byId) {
+        continue;
+      }
+
+      await this.paymentMethodModel.create({
+        _id: card._id,
+        ownerType: PaymentMethodOwnerType.USER,
+        kind: PaymentMethodKind.CREDIT,
+        userId: card.userId,
+        name: card.name,
+        lastFourDigits: card.lastFourDigits,
+        brand: card.type,
+        isActive: card.isActive,
+        migratedFromCardId: card._id,
+      });
+      migrated += 1;
+    }
+
+    if (migrated > 0) {
+      this.logger.log(`Migrated ${migrated} legacy cards to payment methods`);
+    }
+  }
+
+  async create(
+    createDto: CreatePaymentMethodDto,
+    userId: string,
+  ): Promise<PaymentMethod> {
+    this.assertKindAllowed(createDto.kind);
+
+    if (createDto.ownerType === PaymentMethodOwnerType.USER) {
+      const method = new this.paymentMethodModel({
+        ownerType: PaymentMethodOwnerType.USER,
+        kind: createDto.kind,
+        userId: new Types.ObjectId(userId),
+        name: createDto.name.trim(),
+        lastFourDigits: createDto.lastFourDigits,
+        brand: createDto.brand,
+        closingDay: this.resolveClosingDay(
+          createDto.kind,
+          createDto.closingDay,
+        ),
+        dueDay: createDto.dueDay,
+        isActive: true,
+      });
+
+      return method.save();
+    }
+
+    const boardId = resolveBoardId(createDto);
+    if (!boardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+
+    const method = new this.paymentMethodModel({
+      ownerType: PaymentMethodOwnerType.BOARD,
+      kind: createDto.kind,
+      tripId: new Types.ObjectId(boardId),
+      name: createDto.name.trim(),
+      lastFourDigits: createDto.lastFourDigits,
+      brand: createDto.brand,
+      closingDay: this.resolveClosingDay(createDto.kind, createDto.closingDay),
+      dueDay: createDto.dueDay,
+      isActive: true,
+    });
+
+    return method.save();
+  }
+
+  async findByUser(
+    userId: string,
+    includeInactive = false,
+  ): Promise<PaymentMethod[]> {
+    const filter: Record<string, unknown> = {
+      ownerType: PaymentMethodOwnerType.USER,
+      userId: new Types.ObjectId(userId),
+    };
+
+    if (!includeInactive) {
+      filter.isActive = true;
+    }
+
+    return this.paymentMethodModel
+      .find(filter)
+      .sort({ kind: 1, name: 1 })
+      .lean();
+  }
+
+  async findBoardOwned(
+    boardId: string,
+    userId: string,
+    includeInactive = false,
+  ): Promise<PaymentMethod[]> {
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+
+    const filter: Record<string, unknown> = {
+      ownerType: PaymentMethodOwnerType.BOARD,
+      tripId: new Types.ObjectId(boardId),
+    };
+
+    if (!includeInactive) {
+      filter.isActive = true;
+    }
+
+    return this.paymentMethodModel
+      .find(filter)
+      .sort({ kind: 1, name: 1 })
+      .lean();
+  }
+
+  async findAvailableForBoard(
+    boardId: string,
+    userId: string,
+    includeInactive = false,
+  ): Promise<PaymentMethod[]> {
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+
+    const participants = await this.participantsService.findByTrip(
+      boardId,
+      userId,
+    );
+    const participantUserIds = this.extractParticipantUserIds(participants);
+
+    const activeFilter = includeInactive ? {} : { isActive: true };
+
+    return this.paymentMethodModel
+      .find({
+        $or: [
+          {
+            ownerType: PaymentMethodOwnerType.BOARD,
+            tripId: new Types.ObjectId(boardId),
+            ...activeFilter,
+          },
+          {
+            ownerType: PaymentMethodOwnerType.USER,
+            userId: { $in: participantUserIds },
+            ...activeFilter,
+          },
+        ],
+      })
+      .populate('userId', 'firstName lastName')
+      .populate('tripId', 'name')
+      .sort({ ownerType: 1, kind: 1, name: 1 })
+      .lean();
+  }
+
+  async findOne(id: string, userId: string): Promise<PaymentMethod> {
+    const method = await this.paymentMethodModel.findById(id).lean();
+
+    if (!method) {
+      throw new NotFoundException('Medio de pago no encontrado');
+    }
+
+    await this.ensureCanAccess(method, userId);
+
+    return method;
+  }
+
+  async update(
+    id: string,
+    updateDto: UpdatePaymentMethodDto,
+    userId: string,
+  ): Promise<PaymentMethod> {
+    const method = await this.paymentMethodModel.findById(id);
+
+    if (!method) {
+      throw new NotFoundException('Medio de pago no encontrado');
+    }
+
+    await this.ensureCanModify(method, userId);
+
+    if (updateDto.name !== undefined) {
+      method.name = updateDto.name.trim();
+    }
+    if (updateDto.lastFourDigits !== undefined) {
+      method.lastFourDigits = updateDto.lastFourDigits;
+    }
+    if (updateDto.brand !== undefined) {
+      method.brand = updateDto.brand;
+    }
+    if (updateDto.closingDay !== undefined) {
+      method.closingDay = this.resolveClosingDay(
+        method.kind,
+        updateDto.closingDay,
+      );
+    }
+    if (updateDto.dueDay !== undefined) {
+      method.dueDay = updateDto.dueDay;
+    }
+    if (updateDto.isActive !== undefined) {
+      method.isActive = updateDto.isActive;
+    }
+
+    return method.save();
+  }
+
+  async archive(id: string, userId: string): Promise<PaymentMethod> {
+    return this.update(id, { isActive: false }, userId);
+  }
+
+  async deleteByBoard(boardId: string): Promise<void> {
+    await this.paymentMethodModel.deleteMany({
+      ownerType: PaymentMethodOwnerType.BOARD,
+      tripId: new Types.ObjectId(boardId),
+    });
+  }
+
+  private async ensureCanAccess(
+    method: PaymentMethod,
+    userId: string,
+  ): Promise<void> {
+    if (method.ownerType === PaymentMethodOwnerType.USER) {
+      if (method.userId?.toString() !== userId) {
+        throw new BadRequestException(
+          'No tienes permiso para acceder a este medio de pago',
+        );
+      }
+      return;
+    }
+
+    if (!method.tripId) {
+      throw new BadRequestException('Medio de pago del tablero inválido');
+    }
+
+    await this.participantsService.ensureParticipantAccess(
+      method.tripId.toString(),
+      userId,
+    );
+  }
+
+  private async ensureCanModify(
+    method: PaymentMethodDocument,
+    userId: string,
+  ): Promise<void> {
+    if (method.ownerType === PaymentMethodOwnerType.USER) {
+      if (method.userId?.toString() !== userId) {
+        throw new BadRequestException(
+          'No tienes permiso para modificar este medio de pago',
+        );
+      }
+      return;
+    }
+
+    if (!method.tripId) {
+      throw new BadRequestException('Medio de pago del tablero inválido');
+    }
+
+    await this.participantsService.ensureParticipantAccess(
+      method.tripId.toString(),
+      userId,
+    );
+  }
+
+  private assertKindAllowed(kind: PaymentMethodKind): void {
+    const allowed = [
+      PaymentMethodKind.CASH,
+      PaymentMethodKind.DEBIT,
+      PaymentMethodKind.CREDIT,
+    ];
+    if (!allowed.includes(kind)) {
+      throw new BadRequestException('kind debe ser cash, debit o credit');
+    }
+  }
+
+  private resolveClosingDay(
+    kind: PaymentMethodKind,
+    closingDay?: number,
+  ): number | undefined {
+    if (closingDay === undefined) {
+      return undefined;
+    }
+
+    if (kind !== PaymentMethodKind.CREDIT) {
+      throw new BadRequestException(
+        'closingDay solo aplica a medios de pago de crédito',
+      );
+    }
+
+    if (closingDay < 1 || closingDay > 28) {
+      throw new BadRequestException('closingDay debe estar entre 1 y 28');
+    }
+
+    return closingDay;
+  }
+
+  private extractParticipantUserIds(
+    participants: Awaited<ReturnType<ParticipantsService['findByTrip']>>,
+  ): Types.ObjectId[] {
+    const participantUserIds: Types.ObjectId[] = [];
+
+    for (const p of participants) {
+      if (!p.userId) {
+        continue;
+      }
+
+      if (p.userId instanceof Types.ObjectId) {
+        participantUserIds.push(p.userId);
+      } else if (typeof p.userId === 'object' && p.userId !== null) {
+        const userDoc = p.userId as UserDocument;
+        if ('_id' in userDoc && userDoc._id) {
+          participantUserIds.push(new Types.ObjectId(userDoc._id.toString()));
+        } else if ('id' in userDoc && userDoc.id) {
+          const idValue = userDoc.id;
+          if (idValue instanceof Types.ObjectId) {
+            participantUserIds.push(idValue);
+          } else if (
+            typeof idValue === 'string' ||
+            typeof idValue === 'number'
+          ) {
+            participantUserIds.push(new Types.ObjectId(String(idValue)));
+          }
+        }
+      } else {
+        try {
+          participantUserIds.push(new Types.ObjectId(String(p.userId)));
+        } catch {
+          continue;
+        }
+      }
+    }
+
+    return participantUserIds;
+  }
+}

--- a/src/trips/boards.service.spec.ts
+++ b/src/trips/boards.service.spec.ts
@@ -15,6 +15,7 @@ import { Budget } from '../budgets/budget.schema';
 import { Invitation } from '../participants/schemas/invitation.schema';
 import { Types } from 'mongoose';
 import { CategoriesService } from '../categories/categories.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
 
 describe('BoardsService', () => {
   let service: BoardsService;
@@ -50,6 +51,10 @@ describe('BoardsService', () => {
     deleteByBoard: jest.fn().mockResolvedValue(undefined),
   };
 
+  const paymentMethodsService = {
+    deleteByBoard: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -64,6 +69,7 @@ describe('BoardsService', () => {
         { provide: getModelToken(Budget.name), useValue: budgetModel },
         { provide: getModelToken(Invitation.name), useValue: invitationModel },
         { provide: CategoriesService, useValue: categoriesService },
+        { provide: PaymentMethodsService, useValue: paymentMethodsService },
       ],
     }).compile();
 
@@ -110,6 +116,7 @@ describe('BoardsService', () => {
             useValue: invitationModel,
           },
           { provide: CategoriesService, useValue: categoriesService },
+          { provide: PaymentMethodsService, useValue: paymentMethodsService },
         ],
       }).compile();
 
@@ -159,6 +166,7 @@ describe('BoardsService', () => {
             useValue: invitationModel,
           },
           { provide: CategoriesService, useValue: categoriesService },
+          { provide: PaymentMethodsService, useValue: paymentMethodsService },
         ],
       }).compile();
 

--- a/src/trips/trips.module.ts
+++ b/src/trips/trips.module.ts
@@ -10,6 +10,7 @@ import {
   InvitationSchema,
 } from '../participants/schemas/invitation.schema';
 import { CategoriesModule } from '../categories/categories.module';
+import { PaymentMethodsModule } from '../payment-methods/payment-methods.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { CategoriesModule } from '../categories/categories.module';
     ]),
     forwardRef(() => ParticipantsModule),
     forwardRef(() => CategoriesModule),
+    forwardRef(() => PaymentMethodsModule),
   ],
   controllers: [BoardsController],
   providers: [BoardsService],

--- a/src/trips/trips.service.ts
+++ b/src/trips/trips.service.ts
@@ -25,6 +25,7 @@ import { CreateBoardDto } from './dto/create-board.dto';
 import { UpdateBoardDto } from './dto/update-board.dto';
 import { DEFAULT_CURRENCY } from '../common/constants/currencies';
 import { CategoriesService } from '../categories/categories.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
 
 @Injectable()
 export class BoardsService implements OnModuleInit {
@@ -39,6 +40,8 @@ export class BoardsService implements OnModuleInit {
     private invitationModel: Model<InvitationDocument>,
     @Inject(forwardRef(() => CategoriesService))
     private categoriesService: CategoriesService,
+    @Inject(forwardRef(() => PaymentMethodsService))
+    private paymentMethodsService: PaymentMethodsService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -231,6 +234,7 @@ export class BoardsService implements OnModuleInit {
 
     await this.budgetModel.deleteMany({ tripId: boardId });
     await this.categoriesService.deleteByBoard(id);
+    await this.paymentMethodsService.deleteByBoard(id);
     await this.participantModel.deleteMany({ tripId: boardId });
     await this.invitationModel.deleteMany({ tripId: boardId });
     await this.boardModel.findByIdAndDelete(id);


### PR DESCRIPTION
## Summary

- Nuevo módulo `PaymentMethods` con CRUD autenticado para métodos **user-owned** y **board-owned**.
- Soporte MVP: `kind` cash|debit|credit, `closingDay` (1–28, opcional en crédito), `dueDay` opcional.
- `GET /api/payment-methods?boardId=` lista métodos disponibles para gastar (user de miembros + board).
- Migración idempotente de `cards` legacy al boot; `/cards` delega al nuevo servicio (bot compatible).
- Limpieza de métodos board-owned al eliminar un tablero.

Closes #4

## Criterios de aceptación

- [x] CRUD user-owned y board-owned
- [x] kind solo cash|debit|credit en MVP
- [x] closingDay validado 1–28; crear crédito sin closingDay permitido
- [x] Listar métodos disponibles para gastar en un board (user del miembro + board)

## Cómo probarlo

1. Levantar Mongo y backend: `npm run start:dev`
2. Autenticarse y crear/obtener un `boardId`
3. Crear Visa crédito user: `POST /api/payment-methods` con body:
   ```json
   {
     "ownerType": "user",
     "kind": "credit",
     "name": "Visa",
     "lastFourDigits": "4242",
     "closingDay": 14
   }
   ```
4. Crear efectivo board-owned: `POST /api/payment-methods` con body:
   ```json
   {
     "ownerType": "board",
     "boardId": "<boardId>",
     "kind": "cash",
     "name": "Efectivo hogar"
   }
   ```
5. Listar para gastar: `GET /api/payment-methods?boardId=<boardId>` → incluye user + board
6. Validación: `POST` crédito con `closingDay: 31` → `400`
7. Listar solo user: `GET /api/payment-methods?scope=user`
8. `npm run lint && npm run test && npm run build`

## Requiere antes de deploy

Ninguno (sin env vars nuevas; migración automática en boot desde `cards`).

## Notas para el reviewer

- `expense.cardId` ahora referencia `PaymentMethod` (mismos `_id` tras migración).
- Rutas `/cards` siguen operativas vía `CardsService` → solo débito/crédito para compat Telegram.
- `paymentMethodId` en expenses queda para issue #5; este PR no cambia la API de gastos.