### PR TITLE
[Issue #5] Expenses scoped a Board (everyday + compat travel)

### DIFF
--- a/src/bot/bot.service.ts
+++ b/src/bot/bot.service.ts
@@ -2193,6 +2193,7 @@ export class BotService {
         status: (expense.status as ExpenseStatus) || ExpenseStatus.PAID,
         paymentMethod:
           (expense.paymentMethod as PaymentMethod) || PaymentMethod.CASH,
+        paymentMethodId: expense.cardId,
         cardId: expense.cardId,
         isDivisible: expense.isDivisible || false,
         splitType: expense.splitType as SplitType | undefined,

--- a/src/expenses/dto/create-expense.dto.ts
+++ b/src/expenses/dto/create-expense.dto.ts
@@ -74,6 +74,10 @@ export class CreateExpenseDto {
   category?: string;
 
   @IsOptional()
+  @IsMongoId({ message: 'El ID de la categoría no es válido' })
+  categoryId?: string;
+
+  @IsOptional()
   @IsMongoId({ message: 'El ID del participante no es válido' })
   paidByParticipantId?: string;
 
@@ -92,6 +96,10 @@ export class CreateExpenseDto {
   @IsOptional()
   @IsMongoId({ message: 'El ID de la tarjeta no es válido' })
   cardId?: string;
+
+  @IsOptional()
+  @IsMongoId({ message: 'El ID del medio de pago no es válido' })
+  paymentMethodId?: string;
 
   @IsOptional()
   @IsBoolean()

--- a/src/expenses/dto/update-expense.dto.ts
+++ b/src/expenses/dto/update-expense.dto.ts
@@ -19,6 +19,10 @@ import { SUPPORTED_CURRENCIES } from '../../common/constants/currencies';
 
 export class UpdateExpenseDto {
   @IsOptional()
+  @IsMongoId({ message: 'El ID del tablero no es válido' })
+  boardId?: string;
+
+  @IsOptional()
   @IsMongoId({ message: 'El ID del viaje no es válido' })
   tripId?: string;
 
@@ -66,6 +70,10 @@ export class UpdateExpenseDto {
   category?: string;
 
   @IsOptional()
+  @IsMongoId({ message: 'El ID de la categoría no es válido' })
+  categoryId?: string;
+
+  @IsOptional()
   @IsMongoId({ message: 'El ID del participante no es válido' })
   paidByParticipantId?: string;
 
@@ -84,6 +92,10 @@ export class UpdateExpenseDto {
   @IsOptional()
   @IsMongoId({ message: 'El ID de la tarjeta no es válido' })
   cardId?: string;
+
+  @IsOptional()
+  @IsMongoId({ message: 'El ID del medio de pago no es válido' })
+  paymentMethodId?: string;
 
   @IsOptional()
   @IsBoolean()

--- a/src/expenses/expense.schema.ts
+++ b/src/expenses/expense.schema.ts
@@ -48,6 +48,9 @@ export class Expense {
   @Prop({ required: false, maxlength: 50 })
   category?: string;
 
+  @Prop({ type: Types.ObjectId, ref: 'Category', required: false })
+  categoryId?: Types.ObjectId;
+
   @Prop({ type: Types.ObjectId, ref: 'Participant', required: true })
   paidByParticipantId: Types.ObjectId;
 
@@ -69,6 +72,9 @@ export class Expense {
 
   @Prop({ type: Types.ObjectId, ref: 'PaymentMethod', required: false })
   cardId?: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: 'PaymentMethod', required: false })
+  paymentMethodId?: Types.ObjectId;
 
   @Prop({ type: Boolean, default: false, required: true })
   isDivisible: boolean;
@@ -130,6 +136,7 @@ export type ExpenseDocument = Expense & Document;
 export const ExpenseSchema = SchemaFactory.createForClass(Expense);
 
 ExpenseSchema.index({ tripId: 1, createdAt: -1 });
+ExpenseSchema.index({ tripId: 1, expenseDate: -1 });
 ExpenseSchema.index(
   { budgetId: 1 },
   { partialFilterExpression: { budgetId: { $exists: true } } },
@@ -138,3 +145,5 @@ ExpenseSchema.index({ paidByParticipantId: 1 });
 ExpenseSchema.index({ status: 1 });
 ExpenseSchema.index({ expenseDate: -1 });
 ExpenseSchema.index({ cardId: 1 });
+ExpenseSchema.index({ categoryId: 1 });
+ExpenseSchema.index({ paymentMethodId: 1 });

--- a/src/expenses/expenses.board-gates.spec.ts
+++ b/src/expenses/expenses.board-gates.spec.ts
@@ -8,6 +8,8 @@ import { Budget } from '../budgets/budget.schema';
 import { Participant } from '../participants/schemas/participant.schema';
 import { BoardsService } from '../trips/trips.service';
 import { BoardType } from '../trips/board.schema';
+import { CategoriesService } from '../categories/categories.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
 
 describe('ExpensesService board gates', () => {
   let service: ExpensesService;
@@ -37,6 +39,14 @@ describe('ExpensesService board gates', () => {
     isTravelBoard: jest.fn(),
   };
 
+  const categoriesService = {
+    findOne: jest.fn(),
+  };
+
+  const paymentMethodsService = {
+    findAvailableForBoard: jest.fn(),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -50,6 +60,8 @@ describe('ExpensesService board gates', () => {
           useValue: participantModel,
         },
         { provide: BoardsService, useValue: boardsService },
+        { provide: CategoriesService, useValue: categoriesService },
+        { provide: PaymentMethodsService, useValue: paymentMethodsService },
       ],
     }).compile();
 
@@ -147,6 +159,8 @@ describe('ExpensesService board gates', () => {
             useValue: participantModel,
           },
           { provide: BoardsService, useValue: boardsService },
+          { provide: CategoriesService, useValue: categoriesService },
+          { provide: PaymentMethodsService, useValue: paymentMethodsService },
         ],
       }).compile();
 

--- a/src/expenses/expenses.category-payment.spec.ts
+++ b/src/expenses/expenses.category-payment.spec.ts
@@ -3,7 +3,7 @@ import { getModelToken } from '@nestjs/mongoose';
 import { BadRequestException } from '@nestjs/common';
 import { Types } from 'mongoose';
 import { ExpensesService } from './expenses.service';
-import { Expense } from './expense.schema';
+import { Expense, ExpenseStatus, PaymentMethod } from './expense.schema';
 import { Budget } from '../budgets/budget.schema';
 import { Participant } from '../participants/schemas/participant.schema';
 import { BoardsService } from '../trips/trips.service';
@@ -15,6 +15,7 @@ describe('ExpensesService category and payment methods', () => {
   let service: ExpensesService;
 
   const boardId = new Types.ObjectId();
+  const expenseId = new Types.ObjectId();
   const participantId = new Types.ObjectId();
   const categoryId = new Types.ObjectId();
   const paymentMethodId = new Types.ObjectId();
@@ -144,9 +145,92 @@ describe('ExpensesService category and payment methods', () => {
         categoryId: categoryId,
         expenseDate: {
           $gte: new Date('2026-07-01'),
-          $lte: new Date('2026-07-31'),
+          $lt: new Date('2026-08-01'),
         },
       });
+    });
+
+    it('should match paymentMethodId filter on legacy cardId field', async () => {
+      participantModel.findOne.mockResolvedValue({ _id: participantId });
+
+      const leanMock = jest.fn().mockResolvedValue([]);
+      const sortMock = jest.fn().mockReturnValue({ lean: leanMock });
+      const populateChain = {
+        populate: jest.fn().mockReturnThis(),
+        sort: sortMock,
+      };
+
+      expenseModel.find.mockReturnValue(populateChain);
+
+      await service.findAll(boardId.toString(), userId, {
+        paymentMethodId: paymentMethodId.toString(),
+      });
+
+      expect(expenseModel.find).toHaveBeenCalledWith({
+        tripId: boardId,
+        $or: [
+          { paymentMethodId: paymentMethodId },
+          { cardId: paymentMethodId },
+        ],
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('should preserve legacy cardId when payment method is not in the patch', async () => {
+      const legacyCardId = new Types.ObjectId();
+      const expenseDoc = {
+        _id: expenseId,
+        tripId: boardId,
+        amount: 10,
+        status: ExpenseStatus.PAID,
+        isDivisible: false,
+        splits: [],
+        paymentMethod: PaymentMethod.CARD,
+        cardId: legacyCardId,
+        paymentMethodId: undefined,
+        paidByParticipantId: participantId,
+        expenseDate: new Date('2026-07-15'),
+        save: jest.fn().mockResolvedValue({
+          _id: expenseId,
+          tripId: boardId,
+          cardId: legacyCardId,
+          paymentMethodId: legacyCardId,
+        }),
+      };
+
+      expenseModel.findById.mockResolvedValueOnce(expenseDoc).mockReturnValue({
+        populate: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue({
+          _id: expenseId,
+          tripId: boardId,
+          cardId: legacyCardId,
+          paymentMethodId: legacyCardId,
+          paidByParticipantId: participantId,
+          createdBy: new Types.ObjectId(userId),
+          isDivisible: false,
+          status: ExpenseStatus.PAID,
+          expenseDate: new Date('2026-07-15'),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      });
+
+      boardsService.findByIdOrFail.mockResolvedValue({
+        _id: boardId,
+        type: BoardType.EVERYDAY,
+      });
+      participantModel.findOne.mockResolvedValue({ _id: participantId });
+
+      await service.update(
+        expenseId.toString(),
+        { description: 'Descripción actualizada' },
+        userId,
+      );
+
+      expect(expenseDoc.cardId).toEqual(legacyCardId);
+      expect(expenseDoc.paymentMethodId).toEqual(legacyCardId);
+      expect(expenseDoc.save).toHaveBeenCalled();
     });
   });
 });

--- a/src/expenses/expenses.category-payment.spec.ts
+++ b/src/expenses/expenses.category-payment.spec.ts
@@ -1,0 +1,152 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { BadRequestException } from '@nestjs/common';
+import { Types } from 'mongoose';
+import { ExpensesService } from './expenses.service';
+import { Expense } from './expense.schema';
+import { Budget } from '../budgets/budget.schema';
+import { Participant } from '../participants/schemas/participant.schema';
+import { BoardsService } from '../trips/trips.service';
+import { BoardType } from '../trips/board.schema';
+import { CategoriesService } from '../categories/categories.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+
+describe('ExpensesService category and payment methods', () => {
+  let service: ExpensesService;
+
+  const boardId = new Types.ObjectId();
+  const participantId = new Types.ObjectId();
+  const categoryId = new Types.ObjectId();
+  const paymentMethodId = new Types.ObjectId();
+  const userId = new Types.ObjectId().toString();
+
+  const expenseModel = {
+    find: jest.fn(),
+    findById: jest.fn(),
+    updateOne: jest.fn(),
+    prototype: { save: jest.fn() },
+  };
+
+  const budgetModel = {
+    findById: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+  };
+
+  const participantModel = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const boardsService = {
+    findByIdOrFail: jest.fn(),
+    assertTravelFeatures: jest.fn(),
+    isTravelBoard: jest.fn(),
+  };
+
+  const categoriesService = {
+    findOne: jest.fn(),
+  };
+
+  const paymentMethodsService = {
+    findAvailableForBoard: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExpensesService,
+        { provide: getModelToken(Expense.name), useValue: expenseModel },
+        { provide: getModelToken(Budget.name), useValue: budgetModel },
+        {
+          provide: getModelToken(Participant.name),
+          useValue: participantModel,
+        },
+        { provide: BoardsService, useValue: boardsService },
+        { provide: CategoriesService, useValue: categoriesService },
+        { provide: PaymentMethodsService, useValue: paymentMethodsService },
+      ],
+    }).compile();
+
+    service = module.get(ExpensesService);
+  });
+
+  describe('create', () => {
+    it('should reject categoryId from another board', async () => {
+      boardsService.findByIdOrFail.mockResolvedValue({
+        _id: boardId,
+        type: BoardType.EVERYDAY,
+      });
+      participantModel.findOne.mockResolvedValue({ _id: participantId });
+      categoriesService.findOne.mockResolvedValue({
+        _id: categoryId,
+        tripId: new Types.ObjectId(),
+        isActive: true,
+      });
+
+      await expect(
+        service.create(
+          {
+            boardId: boardId.toString(),
+            amount: 25,
+            description: 'Almuerzo',
+            categoryId: categoryId.toString(),
+          },
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should reject paymentMethodId not available for board', async () => {
+      boardsService.findByIdOrFail.mockResolvedValue({
+        _id: boardId,
+        type: BoardType.EVERYDAY,
+      });
+      participantModel.findOne.mockResolvedValue({ _id: participantId });
+      paymentMethodsService.findAvailableForBoard.mockResolvedValue([]);
+
+      await expect(
+        service.create(
+          {
+            boardId: boardId.toString(),
+            amount: 25,
+            description: 'Almuerzo',
+            paymentMethodId: paymentMethodId.toString(),
+          },
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should apply categoryId and date filters', async () => {
+      participantModel.findOne.mockResolvedValue({ _id: participantId });
+
+      const leanMock = jest.fn().mockResolvedValue([]);
+      const sortMock = jest.fn().mockReturnValue({ lean: leanMock });
+      const populateChain = {
+        populate: jest.fn().mockReturnThis(),
+        sort: sortMock,
+      };
+
+      expenseModel.find.mockReturnValue(populateChain);
+
+      await service.findAll(boardId.toString(), userId, {
+        categoryId: categoryId.toString(),
+        from: '2026-07-01',
+        to: '2026-07-31',
+      });
+
+      expect(expenseModel.find).toHaveBeenCalledWith({
+        tripId: boardId,
+        categoryId: categoryId,
+        expenseDate: {
+          $gte: new Date('2026-07-01'),
+          $lte: new Date('2026-07-31'),
+        },
+      });
+    });
+  });
+});

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -44,6 +44,10 @@ export class ExpensesController {
     @Query('boardId') boardId?: string,
     @Query('budgetId') budgetId?: string,
     @Query('status') status?: ExpenseStatus,
+    @Query('categoryId') categoryId?: string,
+    @Query('paymentMethodId') paymentMethodId?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
   ) {
     const resolvedBoardId = boardId || tripId;
     if (!resolvedBoardId) {
@@ -55,8 +59,14 @@ export class ExpensesController {
     const expenses = await this.expensesService.findAll(
       resolvedBoardId,
       userId,
-      budgetId,
-      status,
+      {
+        budgetId,
+        status,
+        categoryId,
+        paymentMethodId,
+        from,
+        to,
+      },
     );
 
     return {

--- a/src/expenses/expenses.module.ts
+++ b/src/expenses/expenses.module.ts
@@ -12,6 +12,9 @@ import { ParticipantsModule } from '../participants/participants.module';
 import { BudgetsModule } from '../budgets/budgets.module';
 import { BoardsModule } from '../trips/trips.module';
 
+import { CategoriesModule } from '../categories/categories.module';
+import { PaymentMethodsModule } from '../payment-methods/payment-methods.module';
+
 @Module({
   imports: [
     MongooseModule.forFeature([
@@ -22,6 +25,8 @@ import { BoardsModule } from '../trips/trips.module';
     forwardRef(() => ParticipantsModule),
     forwardRef(() => BudgetsModule),
     forwardRef(() => BoardsModule),
+    forwardRef(() => CategoriesModule),
+    forwardRef(() => PaymentMethodsModule),
   ],
   controllers: [ExpensesController],
   providers: [ExpensesService],

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenException,
   BadRequestException,
   Logger,
+  OnModuleInit,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
@@ -13,6 +14,7 @@ import {
   ExpenseStatus,
   SplitType,
   ExpenseSplit,
+  PaymentMethod as ExpensePaymentMethod,
 } from './expense.schema';
 import { Budget, BudgetDocument } from '../budgets/budget.schema';
 import {
@@ -26,6 +28,21 @@ import { DEFAULT_CURRENCY } from '../common/constants/currencies';
 import { resolveBoardId } from '../common/utils/resolve-board-id';
 import { resolveCardTypeFromBrand } from '../common/utils/card-type-from-brand';
 import { BoardsService } from '../trips/trips.service';
+import { CategoriesService } from '../categories/categories.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+import {
+  PaymentMethod as PaymentMethodEntity,
+  PaymentMethodKind,
+} from '../payment-methods/payment-method.schema';
+
+export interface ExpenseListFilters {
+  budgetId?: string;
+  status?: ExpenseStatus;
+  categoryId?: string;
+  paymentMethodId?: string;
+  from?: string;
+  to?: string;
+}
 
 interface PopulatedUser {
   _id: Types.ObjectId;
@@ -61,6 +78,26 @@ interface PopulatedExpenseSplit {
   percentage?: number;
 }
 
+interface PopulatedCategory {
+  _id: Types.ObjectId;
+  name: string;
+  icon?: string;
+  color?: string;
+  isActive?: boolean;
+}
+
+interface PopulatedPaymentMethodEntity {
+  _id: Types.ObjectId;
+  name: string;
+  lastFourDigits?: string;
+  brand?: string;
+  kind?: PaymentMethodKind;
+  ownerType?: string;
+  closingDay?: number;
+  userId?: PopulatedUser | Types.ObjectId;
+  tripId?: Types.ObjectId;
+}
+
 interface PopulatedExpense {
   _id: Types.ObjectId;
   tripId: Types.ObjectId;
@@ -71,10 +108,12 @@ interface PopulatedExpense {
   merchantName?: string;
   tags?: string[];
   category?: string;
+  categoryId?: PopulatedCategory | Types.ObjectId;
   paidByParticipantId: PopulatedParticipant | Types.ObjectId;
   status: ExpenseStatus;
   paymentMethod?: string;
   cardId?: PopulatedCard | Types.ObjectId;
+  paymentMethodId?: PopulatedPaymentMethodEntity | Types.ObjectId;
   isDivisible: boolean;
   splitType?: SplitType;
   splits?: PopulatedExpenseSplit[];
@@ -142,8 +181,63 @@ function objectIdToString(id: Types.ObjectId | string | undefined): string {
   return String(id);
 }
 
+const EXPENSE_RELATION_POPULATES = [
+  {
+    path: 'paidByParticipantId',
+    select: '_id guestName guestEmail',
+    populate: {
+      path: 'userId',
+      select: 'firstName lastName email',
+    },
+  },
+  { path: 'createdBy', select: 'firstName lastName email' },
+  { path: 'budgetId', select: '_id name' },
+  { path: 'categoryId', select: '_id name icon color isActive' },
+  {
+    path: 'paymentMethodId',
+    select:
+      '_id name lastFourDigits brand kind ownerType closingDay userId tripId',
+    populate: {
+      path: 'userId',
+      select: 'firstName lastName',
+    },
+  },
+  {
+    path: 'cardId',
+    select: '_id name lastFourDigits brand type userId',
+    populate: {
+      path: 'userId',
+      select: 'firstName lastName',
+    },
+  },
+];
+
+function isPopulatedCategory(
+  value: PopulatedCategory | Types.ObjectId,
+): value is PopulatedCategory {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !(value instanceof Types.ObjectId) &&
+    'name' in value &&
+    !('lastFourDigits' in value)
+  );
+}
+
+function isPopulatedPaymentMethodEntity(
+  value: PopulatedPaymentMethodEntity | Types.ObjectId,
+): value is PopulatedPaymentMethodEntity {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !(value instanceof Types.ObjectId) &&
+    'name' in value &&
+    ('kind' in value || 'ownerType' in value || 'lastFourDigits' in value)
+  );
+}
+
 @Injectable()
-export class ExpensesService {
+export class ExpensesService implements OnModuleInit {
   private readonly logger = new Logger(ExpensesService.name);
 
   constructor(
@@ -152,7 +246,34 @@ export class ExpensesService {
     @InjectModel(Participant.name)
     private participantModel: Model<ParticipantDocument>,
     private boardsService: BoardsService,
+    private categoriesService: CategoriesService,
+    private paymentMethodsService: PaymentMethodsService,
   ) {}
+
+  async onModuleInit(): Promise<void> {
+    const legacyExpenses = await this.expenseModel
+      .find({
+        cardId: { $exists: true, $ne: null },
+        paymentMethodId: { $exists: false },
+      })
+      .select('_id cardId')
+      .lean();
+
+    if (legacyExpenses.length === 0) {
+      return;
+    }
+
+    for (const expense of legacyExpenses) {
+      await this.expenseModel.updateOne(
+        { _id: expense._id },
+        { $set: { paymentMethodId: expense.cardId } },
+      );
+    }
+
+    this.logger.log(
+      `Backfilled paymentMethodId on ${legacyExpenses.length} legacy expenses`,
+    );
+  }
 
   async create(
     createExpenseDto: CreateExpenseDto,
@@ -325,18 +446,48 @@ export class ExpensesService {
       ? new Date(createExpenseDto.expenseDate)
       : new Date();
 
+    if (createExpenseDto.categoryId) {
+      await this.assertCategoryBelongsToBoard(
+        boardId,
+        createExpenseDto.categoryId,
+        userId,
+      );
+    }
+
+    const resolvedPaymentMethodId =
+      this.resolvePaymentMethodId(createExpenseDto);
+    let legacyPaymentMethod =
+      createExpenseDto.paymentMethod || ExpensePaymentMethod.CASH;
+    let paymentMethodObjectId: Types.ObjectId | undefined;
+
+    if (resolvedPaymentMethodId) {
+      const method = await this.assertPaymentMethodAvailableForBoard(
+        boardId,
+        userId,
+        resolvedPaymentMethodId,
+      );
+      paymentMethodObjectId = new Types.ObjectId(resolvedPaymentMethodId);
+      legacyPaymentMethod = this.mapKindToLegacyPaymentMethod(method.kind);
+    }
+
     const expense = new this.expenseModel({
-      ...createExpenseDto,
       tripId: new Types.ObjectId(boardId),
       budgetId: createExpenseDto.budgetId
         ? new Types.ObjectId(createExpenseDto.budgetId)
         : undefined,
+      amount: createExpenseDto.amount,
       currency: createExpenseDto.currency || DEFAULT_CURRENCY,
-      paidByParticipantId: new Types.ObjectId(paidByParticipantId),
-      paymentMethod: createExpenseDto.paymentMethod || 'cash',
-      cardId: createExpenseDto.cardId
-        ? new Types.ObjectId(createExpenseDto.cardId)
+      description: createExpenseDto.description,
+      merchantName: createExpenseDto.merchantName,
+      tags: createExpenseDto.tags,
+      category: createExpenseDto.category,
+      categoryId: createExpenseDto.categoryId
+        ? new Types.ObjectId(createExpenseDto.categoryId)
         : undefined,
+      paidByParticipantId: new Types.ObjectId(paidByParticipantId),
+      paymentMethod: legacyPaymentMethod,
+      cardId: paymentMethodObjectId,
+      paymentMethodId: paymentMethodObjectId,
       isDivisible,
       splitType: isDivisible ? createExpenseDto.splitType : undefined,
       splits: processedSplits,
@@ -360,24 +511,7 @@ export class ExpensesService {
 
     const populatedExpense = await this.expenseModel
       .findById(savedExpense._id)
-      .populate({
-        path: 'paidByParticipantId',
-        select: '_id guestName guestEmail',
-        populate: {
-          path: 'userId',
-          select: 'firstName lastName email',
-        },
-      })
-      .populate('createdBy', 'firstName lastName email')
-      .populate('budgetId', '_id name')
-      .populate({
-        path: 'cardId',
-        select: '_id name lastFourDigits brand type userId',
-        populate: {
-          path: 'userId',
-          select: 'firstName lastName',
-        },
-      })
+      .populate(EXPENSE_RELATION_POPULATES)
       .lean();
 
     return this.transformExpense(populatedExpense);
@@ -386,8 +520,7 @@ export class ExpensesService {
   async findAll(
     tripId: string,
     userId: string,
-    budgetId?: string,
-    status?: ExpenseStatus,
+    filters: ExpenseListFilters = {},
   ): Promise<Expense[]> {
     const userParticipant = await this.participantModel.findOne({
       tripId: new Types.ObjectId(tripId),
@@ -404,36 +537,43 @@ export class ExpensesService {
       tripId: Types.ObjectId;
       budgetId?: Types.ObjectId;
       status?: ExpenseStatus;
+      categoryId?: Types.ObjectId;
+      paymentMethodId?: Types.ObjectId;
+      expenseDate?: {
+        $gte?: Date;
+        $lte?: Date;
+      };
     } = { tripId: new Types.ObjectId(tripId) };
 
-    if (budgetId) {
-      query.budgetId = new Types.ObjectId(budgetId);
+    if (filters.budgetId) {
+      query.budgetId = new Types.ObjectId(filters.budgetId);
     }
 
-    if (status) {
-      query.status = status;
+    if (filters.status) {
+      query.status = filters.status;
+    }
+
+    if (filters.categoryId) {
+      query.categoryId = new Types.ObjectId(filters.categoryId);
+    }
+
+    if (filters.paymentMethodId) {
+      query.paymentMethodId = new Types.ObjectId(filters.paymentMethodId);
+    }
+
+    if (filters.from || filters.to) {
+      query.expenseDate = {};
+      if (filters.from) {
+        query.expenseDate.$gte = new Date(filters.from);
+      }
+      if (filters.to) {
+        query.expenseDate.$lte = new Date(filters.to);
+      }
     }
 
     const expenses = await this.expenseModel
       .find(query)
-      .populate({
-        path: 'paidByParticipantId',
-        select: '_id guestName guestEmail',
-        populate: {
-          path: 'userId',
-          select: 'firstName lastName email',
-        },
-      })
-      .populate('createdBy', 'firstName lastName email')
-      .populate('budgetId', '_id name')
-      .populate({
-        path: 'cardId',
-        select: '_id name lastFourDigits brand type userId',
-        populate: {
-          path: 'userId',
-          select: 'firstName lastName',
-        },
-      })
+      .populate(EXPENSE_RELATION_POPULATES)
       .sort({ expenseDate: -1, createdAt: -1 })
       .lean();
 
@@ -443,30 +583,13 @@ export class ExpensesService {
   async findOne(id: string, userId: string): Promise<Expense> {
     const expense = await this.expenseModel
       .findById(id)
-      .populate({
-        path: 'paidByParticipantId',
-        select: '_id guestName guestEmail',
-        populate: {
-          path: 'userId',
-          select: 'firstName lastName email',
-        },
-      })
+      .populate(EXPENSE_RELATION_POPULATES)
       .populate({
         path: 'splits.participantId',
         select: '_id guestName guestEmail',
         populate: {
           path: 'userId',
           select: 'firstName lastName email',
-        },
-      })
-      .populate('createdBy', 'firstName lastName email')
-      .populate('budgetId', '_id name')
-      .populate({
-        path: 'cardId',
-        select: '_id name lastFourDigits brand type userId',
-        populate: {
-          path: 'userId',
-          select: 'firstName lastName',
         },
       })
       .lean();
@@ -564,6 +687,45 @@ export class ExpensesService {
           'El participante que pagó no existe o no pertenece a este viaje',
         );
       }
+    }
+
+    const boardIdStr = expense.tripId.toString();
+
+    if (updateExpenseDto.categoryId) {
+      await this.assertCategoryBelongsToBoard(
+        boardIdStr,
+        updateExpenseDto.categoryId,
+        userId,
+      );
+    }
+
+    const resolvedUpdatePaymentMethodId =
+      this.resolvePaymentMethodId(updateExpenseDto);
+    let updatedPaymentMethodObjectId = expense.paymentMethodId;
+    let updatedLegacyPaymentMethod = expense.paymentMethod;
+
+    if (
+      updateExpenseDto.paymentMethodId !== undefined ||
+      updateExpenseDto.cardId !== undefined
+    ) {
+      if (resolvedUpdatePaymentMethodId) {
+        const method = await this.assertPaymentMethodAvailableForBoard(
+          boardIdStr,
+          userId,
+          resolvedUpdatePaymentMethodId,
+        );
+        updatedPaymentMethodObjectId = new Types.ObjectId(
+          resolvedUpdatePaymentMethodId,
+        );
+        updatedLegacyPaymentMethod = this.mapKindToLegacyPaymentMethod(
+          method.kind,
+        );
+      } else {
+        updatedPaymentMethodObjectId = undefined;
+        updatedLegacyPaymentMethod = ExpensePaymentMethod.CASH;
+      }
+    } else if (updateExpenseDto.paymentMethod !== undefined) {
+      updatedLegacyPaymentMethod = updateExpenseDto.paymentMethod;
     }
 
     const isDivisible =
@@ -682,7 +844,7 @@ export class ExpensesService {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { tripId: _, ...updateFields } = updateExpenseDto;
+    const { tripId: _, boardId: __, ...updateFields } = updateExpenseDto;
 
     Object.assign(expense, {
       ...updateFields,
@@ -695,16 +857,15 @@ export class ExpensesService {
       paidByParticipantId: updateExpenseDto.paidByParticipantId
         ? new Types.ObjectId(updateExpenseDto.paidByParticipantId)
         : expense.paidByParticipantId,
-      paymentMethod:
-        updateExpenseDto.paymentMethod !== undefined
-          ? updateExpenseDto.paymentMethod
-          : expense.paymentMethod,
-      cardId:
-        updateExpenseDto.cardId !== undefined
-          ? updateExpenseDto.cardId
-            ? new Types.ObjectId(updateExpenseDto.cardId)
+      categoryId:
+        updateExpenseDto.categoryId !== undefined
+          ? updateExpenseDto.categoryId
+            ? new Types.ObjectId(updateExpenseDto.categoryId)
             : undefined
-          : expense.cardId,
+          : expense.categoryId,
+      paymentMethod: updatedLegacyPaymentMethod,
+      cardId: updatedPaymentMethodObjectId,
+      paymentMethodId: updatedPaymentMethodObjectId,
       isDivisible,
       splitType: isDivisible
         ? updateExpenseDto.splitType || expense.splitType
@@ -738,30 +899,13 @@ export class ExpensesService {
 
     const populatedExpense = await this.expenseModel
       .findById(updatedExpense._id)
-      .populate({
-        path: 'paidByParticipantId',
-        select: '_id guestName guestEmail',
-        populate: {
-          path: 'userId',
-          select: 'firstName lastName email',
-        },
-      })
+      .populate(EXPENSE_RELATION_POPULATES)
       .populate({
         path: 'splits.participantId',
         select: '_id guestName guestEmail',
         populate: {
           path: 'userId',
           select: 'firstName lastName email',
-        },
-      })
-      .populate('createdBy', 'firstName lastName email')
-      .populate('budgetId', '_id name')
-      .populate({
-        path: 'cardId',
-        select: '_id name lastFourDigits brand type userId',
-        populate: {
-          path: 'userId',
-          select: 'firstName lastName',
         },
       })
       .lean();
@@ -1259,30 +1403,13 @@ export class ExpensesService {
 
     const populatedExpense = await this.expenseModel
       .findById(updatedExpense._id)
-      .populate({
-        path: 'paidByParticipantId',
-        select: '_id guestName guestEmail',
-        populate: {
-          path: 'userId',
-          select: 'firstName lastName email',
-        },
-      })
+      .populate(EXPENSE_RELATION_POPULATES)
       .populate({
         path: 'splits.participantId',
         select: '_id guestName guestEmail',
         populate: {
           path: 'userId',
           select: 'firstName lastName email',
-        },
-      })
-      .populate('createdBy', 'firstName lastName email')
-      .populate('budgetId', '_id name')
-      .populate({
-        path: 'cardId',
-        select: '_id name lastFourDigits brand type userId',
-        populate: {
-          path: 'userId',
-          select: 'firstName lastName',
         },
       })
       .lean();
@@ -1300,6 +1427,7 @@ export class ExpensesService {
 
     transformed._id = objectIdToString(expenseRecord._id);
     transformed.tripId = objectIdToString(expenseRecord.tripId);
+    transformed.boardId = objectIdToString(expenseRecord.tripId);
 
     if (expenseRecord.budgetId) {
       if (isPopulatedBudget(expenseRecord.budgetId)) {
@@ -1310,6 +1438,22 @@ export class ExpensesService {
         transformed.budgetId = objectIdToString(expenseRecord.budgetId._id);
       } else {
         transformed.budgetId = objectIdToString(expenseRecord.budgetId);
+      }
+    }
+
+    if (expenseRecord.categoryId) {
+      if (isPopulatedCategory(expenseRecord.categoryId)) {
+        const category = expenseRecord.categoryId;
+        transformed.category = {
+          _id: objectIdToString(category._id),
+          name: category.name,
+          icon: category.icon,
+          color: category.color,
+          isActive: category.isActive,
+        };
+        transformed.categoryId = objectIdToString(category._id);
+      } else {
+        transformed.categoryId = objectIdToString(expenseRecord.categoryId);
       }
     }
 
@@ -1377,9 +1521,37 @@ export class ExpensesService {
       }
     }
 
-    if (expenseRecord.cardId) {
-      if (isPopulatedCard(expenseRecord.cardId)) {
-        const card = expenseRecord.cardId;
+    const paymentMethodSource =
+      expenseRecord.paymentMethodId ?? expenseRecord.cardId;
+
+    if (paymentMethodSource) {
+      if (isPopulatedPaymentMethodEntity(paymentMethodSource)) {
+        const method = paymentMethodSource;
+        const methodData = {
+          _id: objectIdToString(method._id),
+          name: method.name,
+          lastFourDigits: method.lastFourDigits,
+          kind: method.kind,
+          ownerType: method.ownerType,
+          closingDay: method.closingDay,
+          brand: method.brand,
+          type: resolveCardTypeFromBrand(method.brand, method.kind),
+          user:
+            method.userId && isPopulatedUser(method.userId)
+              ? {
+                  _id: objectIdToString(method.userId._id),
+                  firstName: method.userId.firstName,
+                  lastName: method.userId.lastName,
+                }
+              : undefined,
+        };
+
+        transformed.paymentMethodDetail = methodData;
+        transformed.paymentMethodId = objectIdToString(method._id);
+        transformed.card = methodData;
+        transformed.cardId = objectIdToString(method._id);
+      } else if (isPopulatedCard(paymentMethodSource)) {
+        const card = paymentMethodSource;
         const cardData: {
           _id: string;
           name: string;
@@ -1407,10 +1579,14 @@ export class ExpensesService {
           }
         }
 
+        transformed.paymentMethodDetail = cardData;
+        transformed.paymentMethodId = objectIdToString(card._id);
         transformed.card = cardData;
         transformed.cardId = objectIdToString(card._id);
       } else {
-        transformed.cardId = objectIdToString(expenseRecord.cardId);
+        const idStr = objectIdToString(paymentMethodSource);
+        transformed.paymentMethodId = idStr;
+        transformed.cardId = idStr;
       }
     }
 
@@ -1488,6 +1664,61 @@ export class ExpensesService {
     }
 
     return transformed as unknown as Expense;
+  }
+
+  private resolvePaymentMethodId(dto: {
+    paymentMethodId?: string;
+    cardId?: string;
+  }): string | undefined {
+    return dto.paymentMethodId || dto.cardId;
+  }
+
+  private mapKindToLegacyPaymentMethod(
+    kind: PaymentMethodKind,
+  ): ExpensePaymentMethod {
+    return kind === PaymentMethodKind.CASH
+      ? ExpensePaymentMethod.CASH
+      : ExpensePaymentMethod.CARD;
+  }
+
+  private async assertCategoryBelongsToBoard(
+    boardId: string,
+    categoryId: string,
+    userId: string,
+  ): Promise<void> {
+    const category = await this.categoriesService.findOne(categoryId, userId);
+
+    if (category.tripId.toString() !== boardId) {
+      throw new BadRequestException('La categoría no pertenece a este tablero');
+    }
+
+    if (!category.isActive) {
+      throw new BadRequestException('La categoría no está activa');
+    }
+  }
+
+  private async assertPaymentMethodAvailableForBoard(
+    boardId: string,
+    userId: string,
+    paymentMethodId: string,
+  ): Promise<PaymentMethodEntity> {
+    const available = await this.paymentMethodsService.findAvailableForBoard(
+      boardId,
+      userId,
+    );
+
+    const method = available.find((item) => {
+      const doc = item as PaymentMethodEntity & { _id: Types.ObjectId };
+      return String(doc._id) === paymentMethodId;
+    });
+
+    if (!method) {
+      throw new BadRequestException(
+        'El medio de pago no está disponible para este tablero',
+      );
+    }
+
+    return method;
   }
 
   private transformExpenses(expenses: any[]): Expense[] {

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -212,6 +212,16 @@ const EXPENSE_RELATION_POPULATES = [
   },
 ];
 
+function parseExpenseDateFrom(value: string): Date {
+  return new Date(value);
+}
+
+function parseExpenseDateToExclusive(value: string): Date {
+  const endExclusive = new Date(value);
+  endExclusive.setUTCDate(endExclusive.getUTCDate() + 1);
+  return endExclusive;
+}
+
 function isPopulatedCategory(
   value: PopulatedCategory | Types.ObjectId,
 ): value is PopulatedCategory {
@@ -538,10 +548,12 @@ export class ExpensesService implements OnModuleInit {
       budgetId?: Types.ObjectId;
       status?: ExpenseStatus;
       categoryId?: Types.ObjectId;
-      paymentMethodId?: Types.ObjectId;
+      $or?: Array<
+        { paymentMethodId: Types.ObjectId } | { cardId: Types.ObjectId }
+      >;
       expenseDate?: {
         $gte?: Date;
-        $lte?: Date;
+        $lt?: Date;
       };
     } = { tripId: new Types.ObjectId(tripId) };
 
@@ -558,16 +570,20 @@ export class ExpensesService implements OnModuleInit {
     }
 
     if (filters.paymentMethodId) {
-      query.paymentMethodId = new Types.ObjectId(filters.paymentMethodId);
+      const paymentMethodObjectId = new Types.ObjectId(filters.paymentMethodId);
+      query.$or = [
+        { paymentMethodId: paymentMethodObjectId },
+        { cardId: paymentMethodObjectId },
+      ];
     }
 
     if (filters.from || filters.to) {
       query.expenseDate = {};
       if (filters.from) {
-        query.expenseDate.$gte = new Date(filters.from);
+        query.expenseDate.$gte = parseExpenseDateFrom(filters.from);
       }
       if (filters.to) {
-        query.expenseDate.$lte = new Date(filters.to);
+        query.expenseDate.$lt = parseExpenseDateToExclusive(filters.to);
       }
     }
 
@@ -701,7 +717,8 @@ export class ExpensesService implements OnModuleInit {
 
     const resolvedUpdatePaymentMethodId =
       this.resolvePaymentMethodId(updateExpenseDto);
-    let updatedPaymentMethodObjectId = expense.paymentMethodId;
+    let updatedPaymentMethodObjectId =
+      expense.paymentMethodId ?? expense.cardId;
     let updatedLegacyPaymentMethod = expense.paymentMethod;
 
     if (


### PR DESCRIPTION
## Summary

- Expenses now support `categoryId` and `paymentMethodId` with validation against board-scoped categories and available payment methods (user + board owned).
- List endpoint accepts filters: `from`, `to`, `categoryId`, `paymentMethodId`, plus existing `budgetId` and `status`.
- API responses include `boardId` alias alongside `tripId`; legacy `cardId` is backfilled to `paymentMethodId` on boot.
- Everyday/travel gates, splits, settle, and travel budgets remain as implemented in prior board work.

## Cómo probarlo

1. `npm run start:dev` with MongoDB and a user with an everyday board.
2. `GET /api/categories?boardId=<id>` — pick a category id from defaults.
3. `POST /api/payment-methods` — create a cash/debit/credit method (user or board owned).
4. `POST /api/expenses` with body:
   ```json
   {
     "boardId": "<boardId>",
     "amount": 42.5,
     "description": "Almuerzo",
     "categoryId": "<categoryId>",
     "paymentMethodId": "<paymentMethodId>"
   }
   ```
5. `GET /api/expenses?boardId=<id>&categoryId=<categoryId>&from=2026-07-01&to=2026-07-31` — verify filtered list.
6. Create a travel board expense with splits and `POST /api/expenses/:id/settle` — confirm travel flow still works.
7. `npm run lint && npm run test && npm run build`

## Requiere antes de deploy

Ninguno (schema additive; legacy expenses keep working).

## Notas para el reviewer

- Stored field remains `tripId` per ADR; `boardId` is response/query alias only.
- `cardId` in requests still works as alias for `paymentMethodId` for bot/legacy clients.
- Legacy enum `paymentMethod` (`cash`|`card`) is derived from payment method `kind` when `paymentMethodId` is set.

Closes #5