### PR TITLE
chore: add GitHub CI workflow and PR template

### DIFF
--- a/.github/ISSUE_WORKFLOW.md
+++ b/.github/ISSUE_WORKFLOW.md
@@ -24,3 +24,5 @@ Este proyecto sigue el estándar definido en
 - El número de issue en GitHub no coincide necesariamente con el orden de
   ejecución. Usar `G-NN` (global) o `order-NN` (local).
 - El Developer Agent debe leer este archivo antes de elegir el próximo issue.
+- **CI:** `.github/workflows/ci.yml` corre en PRs a `main` y push a `issue-*`
+  (lint, test, build). El Reviewer debe verificar checks verdes antes de aprobar.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- Qué se implementó (2–4 bullets). -->
+
+Closes #
+
+## Self-review (Developer)
+
+- Commit: `<SHA del HEAD de la rama>`
+- Bugbot: sin issues | N findings (high/medium resueltos)
+- Security: sin issues | N findings (high/medium resueltos)
+
+## Cómo probarlo
+
+<!-- Pasos concretos: comandos, env vars, URLs, resultado esperado. -->
+
+## Requiere antes de deploy
+
+<!-- Env vars, migraciones, o "Ninguno". -->
+
+## Notas para el reviewer
+
+<!-- Decisiones no obvias, trade-offs, o "N/A". -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'issue-*'
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` (lint, test, build on PRs to `main` and push to `issue-*`).
- Add `.github/PULL_REQUEST_TEMPLATE.md` with **Self-review (Developer)** section.
- Document CI in `ISSUE_WORKFLOW.md`.

## Test plan
- [ ] CI job passes on this PR
- [ ] After merge, new PRs get the PR template automatically