### PR TITLE
[Issue #6] Incomes API + resumen mensual (ingresos - gastos)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { BotModule } from './bot/bot.module';
 import { CardsModule } from './cards/cards.module';
 import { CategoriesModule } from './categories/categories.module';
 import { PaymentMethodsModule } from './payment-methods/payment-methods.module';
+import { IncomesModule } from './incomes/incomes.module';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { PaymentMethodsModule } from './payment-methods/payment-methods.module';
     CardsModule,
     CategoriesModule,
     PaymentMethodsModule,
+    IncomesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/utils/parse-year-month.spec.ts
+++ b/src/common/utils/parse-year-month.spec.ts
@@ -1,0 +1,26 @@
+import { BadRequestException } from '@nestjs/common';
+import { parseYearMonth } from './parse-year-month';
+
+describe('parseYearMonth', () => {
+  it('should parse a valid year-month', () => {
+    expect(parseYearMonth('2026-07')).toEqual({
+      from: '2026-07-01',
+      toExclusive: '2026-08-01',
+    });
+  });
+
+  it('should roll over December to January next year', () => {
+    expect(parseYearMonth('2026-12')).toEqual({
+      from: '2026-12-01',
+      toExclusive: '2027-01-01',
+    });
+  });
+
+  it('should reject invalid month', () => {
+    expect(() => parseYearMonth('2026-13')).toThrow(BadRequestException);
+  });
+
+  it('should reject malformed input', () => {
+    expect(() => parseYearMonth('202607')).toThrow(BadRequestException);
+  });
+});

--- a/src/common/utils/parse-year-month.ts
+++ b/src/common/utils/parse-year-month.ts
@@ -1,0 +1,29 @@
+import { BadRequestException } from '@nestjs/common';
+
+const YEAR_MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+export interface YearMonthRange {
+  from: string;
+  toExclusive: string;
+}
+
+export function parseYearMonth(yearMonth: string): YearMonthRange {
+  if (!YEAR_MONTH_PATTERN.test(yearMonth)) {
+    throw new BadRequestException(
+      'yearMonth debe tener formato YYYY-MM (ej. 2026-07)',
+    );
+  }
+
+  const [yearStr, monthStr] = yearMonth.split('-');
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+
+  const from = `${yearMonth}-01`;
+
+  if (month === 12) {
+    return { from, toExclusive: `${year + 1}-01-01` };
+  }
+
+  const nextMonth = String(month + 1).padStart(2, '0');
+  return { from, toExclusive: `${year}-${nextMonth}-01` };
+}

--- a/src/incomes/dto/create-income.dto.ts
+++ b/src/incomes/dto/create-income.dto.ts
@@ -1,0 +1,56 @@
+import {
+  IsNotEmpty,
+  IsString,
+  IsNumber,
+  IsMongoId,
+  IsOptional,
+  IsIn,
+  Min,
+  MinLength,
+  MaxLength,
+  ValidateIf,
+} from 'class-validator';
+import { SUPPORTED_CURRENCIES } from '../../common/constants/currencies';
+
+export class CreateIncomeDto {
+  @ValidateIf((o: CreateIncomeDto) => !o.tripId)
+  @IsNotEmpty({ message: 'boardId o tripId es requerido' })
+  @IsMongoId({ message: 'El ID del tablero no es válido' })
+  boardId?: string;
+
+  @ValidateIf((o: CreateIncomeDto) => !o.boardId)
+  @IsNotEmpty({ message: 'boardId o tripId es requerido' })
+  @IsMongoId({ message: 'El ID del tablero no es válido' })
+  tripId?: string;
+
+  @IsNotEmpty({ message: 'El monto es obligatorio' })
+  @IsNumber({}, { message: 'El monto debe ser un número' })
+  @Min(0.01, { message: 'El monto debe ser mayor a 0' })
+  amount: number;
+
+  @IsOptional()
+  @IsString({ message: 'La moneda debe ser texto' })
+  @IsIn(SUPPORTED_CURRENCIES, {
+    message: 'Moneda no válida',
+  })
+  currency?: string;
+
+  @IsNotEmpty({ message: 'La etiqueta es obligatoria' })
+  @IsString({ message: 'La etiqueta debe ser texto' })
+  @MinLength(1, { message: 'La etiqueta debe tener al menos 1 carácter' })
+  @MaxLength(200, {
+    message: 'La etiqueta no puede tener más de 200 caracteres',
+  })
+  label: string;
+
+  @IsOptional()
+  @IsString({ message: 'La descripción debe ser texto' })
+  @MaxLength(500, {
+    message: 'La descripción no puede tener más de 500 caracteres',
+  })
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  incomeDate?: string;
+}

--- a/src/incomes/dto/update-income.dto.ts
+++ b/src/incomes/dto/update-income.dto.ts
@@ -1,0 +1,43 @@
+import {
+  IsOptional,
+  IsString,
+  IsNumber,
+  IsIn,
+  Min,
+  MinLength,
+  MaxLength,
+} from 'class-validator';
+import { SUPPORTED_CURRENCIES } from '../../common/constants/currencies';
+
+export class UpdateIncomeDto {
+  @IsOptional()
+  @IsNumber({}, { message: 'El monto debe ser un número' })
+  @Min(0.01, { message: 'El monto debe ser mayor a 0' })
+  amount?: number;
+
+  @IsOptional()
+  @IsString({ message: 'La moneda debe ser texto' })
+  @IsIn(SUPPORTED_CURRENCIES, {
+    message: 'Moneda no válida',
+  })
+  currency?: string;
+
+  @IsOptional()
+  @IsString({ message: 'La etiqueta debe ser texto' })
+  @MinLength(1, { message: 'La etiqueta debe tener al menos 1 carácter' })
+  @MaxLength(200, {
+    message: 'La etiqueta no puede tener más de 200 caracteres',
+  })
+  label?: string;
+
+  @IsOptional()
+  @IsString({ message: 'La descripción debe ser texto' })
+  @MaxLength(500, {
+    message: 'La descripción no puede tener más de 500 caracteres',
+  })
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  incomeDate?: string;
+}

--- a/src/incomes/income.schema.ts
+++ b/src/incomes/income.schema.ts
@@ -1,0 +1,39 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Income {
+  @Prop({ type: Types.ObjectId, ref: 'Board', required: true })
+  tripId: Types.ObjectId;
+
+  @Prop({ required: true, min: 0.01 })
+  amount: number;
+
+  @Prop({ required: true, default: 'USD' })
+  currency: string;
+
+  @Prop({ required: true, minlength: 1, maxlength: 200 })
+  label: string;
+
+  @Prop({ required: false, maxlength: 500 })
+  description?: string;
+
+  @Prop({ type: Date, default: Date.now })
+  incomeDate: Date;
+
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  createdBy: Types.ObjectId;
+
+  @Prop({ default: Date.now })
+  createdAt: Date;
+
+  @Prop({ default: Date.now })
+  updatedAt: Date;
+}
+
+export type IncomeDocument = Income & Document;
+
+export const IncomeSchema = SchemaFactory.createForClass(Income);
+
+IncomeSchema.index({ tripId: 1, incomeDate: -1 });
+IncomeSchema.index({ tripId: 1, createdAt: -1 });

--- a/src/incomes/incomes.controller.ts
+++ b/src/incomes/incomes.controller.ts
@@ -1,0 +1,113 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+  Query,
+  BadRequestException,
+} from '@nestjs/common';
+import { IncomesService } from './incomes.service';
+import { CreateIncomeDto } from './dto/create-income.dto';
+import { UpdateIncomeDto } from './dto/update-income.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GetUser } from '../auth/decorators/get-user.decorator';
+import { UserDocument } from '../users/user.schema';
+
+@Controller('incomes')
+@UseGuards(JwtAuthGuard)
+export class IncomesController {
+  constructor(private readonly incomesService: IncomesService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Body() createIncomeDto: CreateIncomeDto,
+    @GetUser() user: UserDocument,
+  ) {
+    const income = await this.incomesService.create(
+      createIncomeDto,
+      user._id.toString(),
+    );
+    return {
+      message: 'Ingreso creado exitosamente',
+      income,
+    };
+  }
+
+  @Get('summary')
+  async getMonthlySummary(
+    @Query('boardId') boardId: string,
+    @Query('yearMonth') yearMonth: string,
+    @GetUser() user: UserDocument,
+    @Query('tripId') tripId?: string,
+  ) {
+    const resolvedBoardId = boardId || tripId;
+    if (!resolvedBoardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+    if (!yearMonth) {
+      throw new BadRequestException('yearMonth es requerido (formato YYYY-MM)');
+    }
+
+    const summary = await this.incomesService.getMonthlySummary(
+      resolvedBoardId,
+      yearMonth,
+      user._id.toString(),
+    );
+
+    return { summary };
+  }
+
+  @Get()
+  async findAllByBoard(
+    @Query('boardId') boardId: string,
+    @GetUser() user: UserDocument,
+    @Query('tripId') tripId?: string,
+  ) {
+    const resolvedBoardId = boardId || tripId;
+    if (!resolvedBoardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+
+    const incomes = await this.incomesService.findAllByBoard(
+      resolvedBoardId,
+      user._id.toString(),
+    );
+    return { incomes };
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string, @GetUser() user: UserDocument) {
+    const income = await this.incomesService.findOne(id, user._id.toString());
+    return { income };
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() updateIncomeDto: UpdateIncomeDto,
+    @GetUser() user: UserDocument,
+  ) {
+    const income = await this.incomesService.update(
+      id,
+      updateIncomeDto,
+      user._id.toString(),
+    );
+    return {
+      message: 'Ingreso actualizado exitosamente',
+      income,
+    };
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id') id: string, @GetUser() user: UserDocument) {
+    await this.incomesService.remove(id, user._id.toString());
+  }
+}

--- a/src/incomes/incomes.module.ts
+++ b/src/incomes/incomes.module.ts
@@ -1,0 +1,23 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { IncomesService } from './incomes.service';
+import { IncomesController } from './incomes.controller';
+import { Income, IncomeSchema } from './income.schema';
+import { Expense, ExpenseSchema } from '../expenses/expense.schema';
+import { ParticipantsModule } from '../participants/participants.module';
+import { BoardsModule } from '../trips/trips.module';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Income.name, schema: IncomeSchema },
+      { name: Expense.name, schema: ExpenseSchema },
+    ]),
+    forwardRef(() => ParticipantsModule),
+    forwardRef(() => BoardsModule),
+  ],
+  controllers: [IncomesController],
+  providers: [IncomesService],
+  exports: [IncomesService, MongooseModule],
+})
+export class IncomesModule {}

--- a/src/incomes/incomes.service.spec.ts
+++ b/src/incomes/incomes.service.spec.ts
@@ -1,0 +1,253 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import {
+  ForbiddenException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { Types } from 'mongoose';
+import { IncomesService } from './incomes.service';
+import { Income } from './income.schema';
+import { Expense } from '../expenses/expense.schema';
+import { ParticipantsService } from '../participants/participants.service';
+import { BoardsService } from '../trips/trips.service';
+
+describe('IncomesService', () => {
+  let service: IncomesService;
+
+  const boardId = new Types.ObjectId();
+  const incomeId = new Types.ObjectId();
+  const userId = new Types.ObjectId().toString();
+
+  const saveMock = jest.fn();
+  const incomeQuery = {
+    find: jest.fn(),
+    findById: jest.fn(),
+    findByIdAndDelete: jest.fn(),
+  };
+
+  const IncomeModelMock = jest.fn().mockImplementation((data: object) => ({
+    ...data,
+    save: saveMock,
+  }));
+  Object.assign(IncomeModelMock, incomeQuery);
+
+  const expenseModel = {
+    find: jest.fn(),
+  };
+
+  const participantsService = {
+    ensureParticipantAccess: jest.fn(),
+  };
+
+  const boardsService = {
+    findByIdOrFail: jest.fn(),
+  };
+
+  const mockIncomeDoc = {
+    _id: incomeId,
+    tripId: boardId,
+    amount: 1000,
+    currency: 'ARS',
+    label: 'Sueldo',
+    incomeDate: new Date('2026-07-15'),
+    save: saveMock,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IncomesService,
+        { provide: getModelToken(Income.name), useValue: IncomeModelMock },
+        { provide: getModelToken(Expense.name), useValue: expenseModel },
+        { provide: ParticipantsService, useValue: participantsService },
+        { provide: BoardsService, useValue: boardsService },
+      ],
+    }).compile();
+
+    service = module.get(IncomesService);
+    participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+    boardsService.findByIdOrFail.mockResolvedValue({
+      _id: boardId,
+      baseCurrency: 'ARS',
+    });
+  });
+
+  describe('create', () => {
+    it('should create income with board default currency', async () => {
+      saveMock.mockResolvedValue({
+        _id: incomeId,
+        amount: 1000,
+        currency: 'ARS',
+        label: 'Sueldo',
+      });
+
+      const result = await service.create(
+        {
+          boardId: boardId.toString(),
+          amount: 1000,
+          label: 'Sueldo',
+        },
+        userId,
+      );
+
+      expect(participantsService.ensureParticipantAccess).toHaveBeenCalledWith(
+        boardId.toString(),
+        userId,
+      );
+      expect(IncomeModelMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: 1000,
+          currency: 'ARS',
+          label: 'Sueldo',
+        }),
+      );
+      expect(saveMock).toHaveBeenCalled();
+      expect(result.currency).toBe('ARS');
+    });
+
+    it('should require boardId', async () => {
+      await expect(
+        service.create({ amount: 100, label: 'Test' } as never, userId),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('findAllByBoard', () => {
+    it('should require participant access', async () => {
+      participantsService.ensureParticipantAccess.mockRejectedValue(
+        new ForbiddenException('No tienes acceso a este viaje'),
+      );
+
+      await expect(
+        service.findAllByBoard(boardId.toString(), userId),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should return incomes sorted by date', async () => {
+      const incomes = [{ _id: incomeId, label: 'Sueldo', amount: 1000 }];
+      const sortMock = jest
+        .fn()
+        .mockReturnValue({ lean: jest.fn().mockResolvedValue(incomes) });
+      incomeQuery.find.mockReturnValue({ sort: sortMock });
+
+      const result = await service.findAllByBoard(boardId.toString(), userId);
+
+      expect(incomeQuery.find).toHaveBeenCalledWith({
+        tripId: boardId,
+      });
+      expect(result).toEqual(incomes);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should throw when income not found', async () => {
+      incomeQuery.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.findOne(incomeId.toString(), userId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should enforce board access', async () => {
+      incomeQuery.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          _id: incomeId,
+          tripId: boardId,
+          label: 'Sueldo',
+        }),
+      });
+
+      const result = await service.findOne(incomeId.toString(), userId);
+
+      expect(participantsService.ensureParticipantAccess).toHaveBeenCalledWith(
+        boardId.toString(),
+        userId,
+      );
+      expect(result.label).toBe('Sueldo');
+    });
+  });
+
+  describe('update', () => {
+    it('should throw when income not found', async () => {
+      incomeQuery.findById.mockResolvedValue(null);
+
+      await expect(
+        service.update(incomeId.toString(), { label: 'Nuevo' }, userId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should update allowed fields', async () => {
+      const doc = { ...mockIncomeDoc };
+      incomeQuery.findById.mockResolvedValue(doc);
+      saveMock.mockResolvedValue({ ...doc, label: 'Bono' });
+
+      const result = await service.update(
+        incomeId.toString(),
+        { label: 'Bono', amount: 500 },
+        userId,
+      );
+
+      expect(doc.label).toBe('Bono');
+      expect(doc.amount).toBe(500);
+      expect(saveMock).toHaveBeenCalled();
+      expect(result.label).toBe('Bono');
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete income after access check', async () => {
+      incomeQuery.findById.mockResolvedValue(mockIncomeDoc);
+      incomeQuery.findByIdAndDelete.mockResolvedValue(mockIncomeDoc);
+
+      await service.remove(incomeId.toString(), userId);
+
+      expect(incomeQuery.findByIdAndDelete).toHaveBeenCalledWith(
+        incomeId.toString(),
+      );
+    });
+  });
+
+  describe('getMonthlySummary', () => {
+    it('should compute remaining = incomes - expenses in board currency', async () => {
+      incomeQuery.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          { amount: 5000, currency: 'ARS' },
+          { amount: 100, currency: 'USD' },
+        ]),
+      });
+      expenseModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          { amount: 1200, currency: 'ARS' },
+          { amount: 50, currency: 'USD' },
+        ]),
+      });
+
+      const summary = await service.getMonthlySummary(
+        boardId.toString(),
+        '2026-07',
+        userId,
+      );
+
+      expect(summary.totalIncomes).toBe(5000);
+      expect(summary.totalExpenses).toBe(1200);
+      expect(summary.remaining).toBe(3800);
+      expect(summary.currency).toBe('ARS');
+      expect(summary.yearMonth).toBe('2026-07');
+      expect(summary.excludedDueToCurrencyMismatch).toEqual({
+        incomes: 1,
+        expenses: 1,
+      });
+    });
+
+    it('should reject invalid yearMonth', async () => {
+      await expect(
+        service.getMonthlySummary(boardId.toString(), '2026-13', userId),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/src/incomes/incomes.service.ts
+++ b/src/incomes/incomes.service.ts
@@ -1,0 +1,237 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Income, IncomeDocument } from './income.schema';
+import { Expense, ExpenseDocument } from '../expenses/expense.schema';
+import { CreateIncomeDto } from './dto/create-income.dto';
+import { UpdateIncomeDto } from './dto/update-income.dto';
+import { ParticipantsService } from '../participants/participants.service';
+import { BoardsService } from '../trips/trips.service';
+import { resolveBoardId } from '../common/utils/resolve-board-id';
+import { parseYearMonth } from '../common/utils/parse-year-month';
+import { DEFAULT_CURRENCY } from '../common/constants/currencies';
+
+export interface MonthlyBoardSummary {
+  boardId: string;
+  yearMonth: string;
+  currency: string;
+  totalIncomes: number;
+  totalExpenses: number;
+  remaining: number;
+  /**
+   * Until FX snapshot (issue #9), only amounts in the board currency are
+   * included in totals. Other-currency rows are counted here.
+   */
+  excludedDueToCurrencyMismatch: {
+    incomes: number;
+    expenses: number;
+  };
+}
+
+function parseIncomeDate(value: string): Date {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new BadRequestException('incomeDate no es una fecha válida');
+  }
+  return parsed;
+}
+
+function parseDateFrom(value: string): Date {
+  return new Date(value);
+}
+
+@Injectable()
+export class IncomesService {
+  private readonly logger = new Logger(IncomesService.name);
+
+  constructor(
+    @InjectModel(Income.name)
+    private incomeModel: Model<IncomeDocument>,
+    @InjectModel(Expense.name)
+    private expenseModel: Model<ExpenseDocument>,
+    private participantsService: ParticipantsService,
+    private boardsService: BoardsService,
+  ) {}
+
+  async create(
+    createIncomeDto: CreateIncomeDto,
+    userId: string,
+  ): Promise<Income> {
+    const boardId = resolveBoardId(createIncomeDto);
+    if (!boardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+
+    const board = await this.boardsService.findByIdOrFail(boardId);
+
+    const income = new this.incomeModel({
+      tripId: new Types.ObjectId(boardId),
+      amount: createIncomeDto.amount,
+      currency:
+        createIncomeDto.currency ?? board.baseCurrency ?? DEFAULT_CURRENCY,
+      label: createIncomeDto.label.trim(),
+      description: createIncomeDto.description?.trim(),
+      incomeDate: createIncomeDto.incomeDate
+        ? parseIncomeDate(createIncomeDto.incomeDate)
+        : new Date(),
+      createdBy: new Types.ObjectId(userId),
+    });
+
+    const saved = await income.save();
+    this.logger.log(
+      `Income created: ${saved._id.toString()} on board ${boardId}`,
+    );
+    return saved;
+  }
+
+  async findAllByBoard(boardId: string, userId: string): Promise<Income[]> {
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+
+    return this.incomeModel
+      .find({ tripId: new Types.ObjectId(boardId) })
+      .sort({ incomeDate: -1, createdAt: -1 })
+      .lean();
+  }
+
+  async findOne(id: string, userId: string): Promise<Income> {
+    const income = await this.incomeModel.findById(id).lean();
+
+    if (!income) {
+      throw new NotFoundException('Ingreso no encontrado');
+    }
+
+    await this.participantsService.ensureParticipantAccess(
+      income.tripId.toString(),
+      userId,
+    );
+
+    return income;
+  }
+
+  async update(
+    id: string,
+    updateIncomeDto: UpdateIncomeDto,
+    userId: string,
+  ): Promise<Income> {
+    const income = await this.incomeModel.findById(id);
+
+    if (!income) {
+      throw new NotFoundException('Ingreso no encontrado');
+    }
+
+    await this.participantsService.ensureParticipantAccess(
+      income.tripId.toString(),
+      userId,
+    );
+
+    if (updateIncomeDto.amount !== undefined) {
+      income.amount = updateIncomeDto.amount;
+    }
+    if (updateIncomeDto.currency !== undefined) {
+      income.currency = updateIncomeDto.currency;
+    }
+    if (updateIncomeDto.label !== undefined) {
+      income.label = updateIncomeDto.label.trim();
+    }
+    if (updateIncomeDto.description !== undefined) {
+      income.description = updateIncomeDto.description.trim();
+    }
+    if (updateIncomeDto.incomeDate !== undefined) {
+      income.incomeDate = parseIncomeDate(updateIncomeDto.incomeDate);
+    }
+
+    const saved = await income.save();
+    this.logger.log(`Income updated: ${id}`);
+    return saved;
+  }
+
+  async remove(id: string, userId: string): Promise<void> {
+    const income = await this.incomeModel.findById(id);
+
+    if (!income) {
+      throw new NotFoundException('Ingreso no encontrado');
+    }
+
+    await this.participantsService.ensureParticipantAccess(
+      income.tripId.toString(),
+      userId,
+    );
+
+    await this.incomeModel.findByIdAndDelete(id);
+    this.logger.log(`Income deleted: ${id}`);
+  }
+
+  async getMonthlySummary(
+    boardId: string,
+    yearMonth: string,
+    userId: string,
+  ): Promise<MonthlyBoardSummary> {
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+
+    const board = await this.boardsService.findByIdOrFail(boardId);
+    const boardCurrency = board.baseCurrency ?? DEFAULT_CURRENCY;
+    const { from, toExclusive } = parseYearMonth(yearMonth);
+
+    const dateFilter = {
+      $gte: parseDateFrom(from),
+      $lt: parseDateFrom(toExclusive),
+    };
+
+    const boardObjectId = new Types.ObjectId(boardId);
+
+    const [incomes, expenses] = await Promise.all([
+      this.incomeModel
+        .find({
+          tripId: boardObjectId,
+          incomeDate: dateFilter,
+        })
+        .lean(),
+      this.expenseModel
+        .find({
+          tripId: boardObjectId,
+          expenseDate: dateFilter,
+        })
+        .lean(),
+    ]);
+
+    let totalIncomes = 0;
+    let excludedIncomes = 0;
+    for (const income of incomes) {
+      if (income.currency === boardCurrency) {
+        totalIncomes += income.amount;
+      } else {
+        excludedIncomes += 1;
+      }
+    }
+
+    let totalExpenses = 0;
+    let excludedExpenses = 0;
+    for (const expense of expenses) {
+      if (expense.currency === boardCurrency) {
+        totalExpenses += expense.amount;
+      } else {
+        excludedExpenses += 1;
+      }
+    }
+
+    return {
+      boardId,
+      yearMonth,
+      currency: boardCurrency,
+      totalIncomes,
+      totalExpenses,
+      remaining: totalIncomes - totalExpenses,
+      excludedDueToCurrencyMismatch: {
+        incomes: excludedIncomes,
+        expenses: excludedExpenses,
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Nuevo módulo `incomes`: schema, CRUD autenticado scoped a tablero (`boardId`/`tripId`).
- Endpoint `GET /api/incomes/summary?boardId=&yearMonth=YYYY-MM` con totales de ingresos, gastos y `remaining` del mes calendario.
- Acceso restringido a miembros del board vía `ensureParticipantAccess`; moneda del resumen = `baseCurrency` del board (montos en otra moneda excluidos hasta issue FX #9).
- Tests unitarios para servicio y utilidad `parseYearMonth`.

Closes #6

## Self-review (Developer)

- Commit: `72828d1baeef400bd3dc055606b33698bf9b5a63`
- Bugbot: 1 finding high (doble `parseDateToExclusive` en filtro mensual) — corregido antes del PR
- Security: sin issues (medium+)

## Cómo probarlo

1. `npm run start:dev` con MongoDB y `.env` configurado.
2. Autenticarse y obtener un `boardId` everyday con gastos en el mes actual.
3. `POST /api/incomes` con body:
   ```json
   { "boardId": "<id>", "amount": 500000, "label": "Sueldo", "incomeDate": "2026-07-15" }
   ```
4. `GET /api/incomes?boardId=<id>` — lista ingresos del tablero.
5. `GET /api/incomes/summary?boardId=<id>&yearMonth=2026-07` — verificar `totalIncomes`, `totalExpenses`, `remaining = incomes - expenses`.
6. `PATCH /api/incomes/<id>` y `DELETE /api/incomes/<id>` — editar y borrar.
7. Probar con usuario no miembro del board → `403 Forbidden`.

## Requiere antes de deploy

Ninguno (colección Mongo `incomes` se crea automáticamente).

## Notas para el reviewer

- El campo interno sigue siendo `tripId` (convención del repo post-migración Board).
- Montos en moneda distinta a `baseCurrency` no entran en el resumen; se reportan en `excludedDueToCurrencyMismatch` hasta el issue de FX (#9).