### PR TITLE
[Issue #7] Presupuestos mensuales por categoría (everyday)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { CardsModule } from './cards/cards.module';
 import { CategoriesModule } from './categories/categories.module';
 import { PaymentMethodsModule } from './payment-methods/payment-methods.module';
 import { IncomesModule } from './incomes/incomes.module';
+import { BoardMonthBudgetsModule } from './board-month-budgets/board-month-budgets.module';
 
 @Module({
   imports: [
@@ -51,6 +52,7 @@ import { IncomesModule } from './incomes/incomes.module';
     CategoriesModule,
     PaymentMethodsModule,
     IncomesModule,
+    BoardMonthBudgetsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/board-month-budgets/board-month-budget.schema.ts
+++ b/src/board-month-budgets/board-month-budget.schema.ts
@@ -1,0 +1,40 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class BoardMonthBudget {
+  @Prop({ type: Types.ObjectId, ref: 'Board', required: true })
+  tripId: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: 'Category', required: true })
+  categoryId: Types.ObjectId;
+
+  @Prop({ required: true })
+  yearMonth: string;
+
+  @Prop({ required: true, min: 0 })
+  limit: number;
+
+  @Prop({ required: true, default: 'USD' })
+  currency: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  createdBy: Types.ObjectId;
+
+  @Prop({ default: Date.now })
+  createdAt: Date;
+
+  @Prop({ default: Date.now })
+  updatedAt: Date;
+}
+
+export type BoardMonthBudgetDocument = BoardMonthBudget & Document;
+
+export const BoardMonthBudgetSchema =
+  SchemaFactory.createForClass(BoardMonthBudget);
+
+BoardMonthBudgetSchema.index(
+  { tripId: 1, categoryId: 1, yearMonth: 1 },
+  { unique: true },
+);
+BoardMonthBudgetSchema.index({ tripId: 1, yearMonth: 1 });

--- a/src/board-month-budgets/board-month-budgets.controller.ts
+++ b/src/board-month-budgets/board-month-budgets.controller.ts
@@ -1,0 +1,124 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+  Query,
+  BadRequestException,
+} from '@nestjs/common';
+import { BoardMonthBudgetsService } from './board-month-budgets.service';
+import { CreateBoardMonthBudgetDto } from './dto/create-board-month-budget.dto';
+import { UpdateBoardMonthBudgetDto } from './dto/update-board-month-budget.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GetUser } from '../auth/decorators/get-user.decorator';
+import { UserDocument } from '../users/user.schema';
+
+@Controller('board-month-budgets')
+@UseGuards(JwtAuthGuard)
+export class BoardMonthBudgetsController {
+  constructor(
+    private readonly boardMonthBudgetsService: BoardMonthBudgetsService,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Body() createDto: CreateBoardMonthBudgetDto,
+    @GetUser() user: UserDocument,
+  ) {
+    const budget = await this.boardMonthBudgetsService.create(
+      createDto,
+      user._id.toString(),
+    );
+    return {
+      message: 'Presupuesto mensual creado exitosamente',
+      budget,
+    };
+  }
+
+  @Get('progress')
+  async getProgress(
+    @Query('boardId') boardId: string,
+    @Query('yearMonth') yearMonth: string,
+    @GetUser() user: UserDocument,
+    @Query('tripId') tripId?: string,
+  ) {
+    const resolvedBoardId = boardId || tripId;
+    if (!resolvedBoardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+    if (!yearMonth) {
+      throw new BadRequestException('yearMonth es requerido (formato YYYY-MM)');
+    }
+
+    const progress = await this.boardMonthBudgetsService.getProgress(
+      resolvedBoardId,
+      yearMonth,
+      user._id.toString(),
+    );
+
+    return { progress };
+  }
+
+  @Get()
+  async findAllByBoardAndMonth(
+    @Query('boardId') boardId: string,
+    @Query('yearMonth') yearMonth: string,
+    @GetUser() user: UserDocument,
+    @Query('tripId') tripId?: string,
+  ) {
+    const resolvedBoardId = boardId || tripId;
+    if (!resolvedBoardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+    if (!yearMonth) {
+      throw new BadRequestException('yearMonth es requerido (formato YYYY-MM)');
+    }
+
+    const budgets = await this.boardMonthBudgetsService.findAllByBoardAndMonth(
+      resolvedBoardId,
+      yearMonth,
+      user._id.toString(),
+    );
+
+    return { budgets };
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string, @GetUser() user: UserDocument) {
+    const budget = await this.boardMonthBudgetsService.findOne(
+      id,
+      user._id.toString(),
+    );
+    return { budget };
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() updateDto: UpdateBoardMonthBudgetDto,
+    @GetUser() user: UserDocument,
+  ) {
+    const budget = await this.boardMonthBudgetsService.update(
+      id,
+      updateDto,
+      user._id.toString(),
+    );
+    return {
+      message: 'Presupuesto mensual actualizado exitosamente',
+      budget,
+    };
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id') id: string, @GetUser() user: UserDocument) {
+    await this.boardMonthBudgetsService.remove(id, user._id.toString());
+  }
+}

--- a/src/board-month-budgets/board-month-budgets.module.ts
+++ b/src/board-month-budgets/board-month-budgets.module.ts
@@ -1,0 +1,28 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { BoardMonthBudgetsService } from './board-month-budgets.service';
+import { BoardMonthBudgetsController } from './board-month-budgets.controller';
+import {
+  BoardMonthBudget,
+  BoardMonthBudgetSchema,
+} from './board-month-budget.schema';
+import { Expense, ExpenseSchema } from '../expenses/expense.schema';
+import { ParticipantsModule } from '../participants/participants.module';
+import { BoardsModule } from '../trips/trips.module';
+import { CategoriesModule } from '../categories/categories.module';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: BoardMonthBudget.name, schema: BoardMonthBudgetSchema },
+      { name: Expense.name, schema: ExpenseSchema },
+    ]),
+    forwardRef(() => ParticipantsModule),
+    forwardRef(() => BoardsModule),
+    forwardRef(() => CategoriesModule),
+  ],
+  controllers: [BoardMonthBudgetsController],
+  providers: [BoardMonthBudgetsService],
+  exports: [BoardMonthBudgetsService, MongooseModule],
+})
+export class BoardMonthBudgetsModule {}

--- a/src/board-month-budgets/board-month-budgets.service.spec.ts
+++ b/src/board-month-budgets/board-month-budgets.service.spec.ts
@@ -1,0 +1,358 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import {
+  ForbiddenException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { Types } from 'mongoose';
+import { BoardMonthBudgetsService } from './board-month-budgets.service';
+import { BoardMonthBudget } from './board-month-budget.schema';
+import { Expense } from '../expenses/expense.schema';
+import { ParticipantsService } from '../participants/participants.service';
+import { BoardsService } from '../trips/trips.service';
+import { CategoriesService } from '../categories/categories.service';
+
+describe('BoardMonthBudgetsService', () => {
+  let service: BoardMonthBudgetsService;
+
+  const boardId = new Types.ObjectId();
+  const categoryId = new Types.ObjectId();
+  const budgetId = new Types.ObjectId();
+  const userId = new Types.ObjectId().toString();
+
+  const saveMock = jest.fn();
+  const budgetQuery = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    findById: jest.fn(),
+    findByIdAndDelete: jest.fn(),
+  };
+
+  const BudgetModelMock = jest.fn().mockImplementation((data: object) => ({
+    ...data,
+    save: saveMock,
+  }));
+  Object.assign(BudgetModelMock, budgetQuery);
+
+  const expenseModel = {
+    find: jest.fn(),
+  };
+
+  const participantsService = {
+    ensureParticipantAccess: jest.fn(),
+  };
+
+  const boardsService = {
+    assertEverydayFeatures: jest.fn(),
+    findByIdOrFail: jest.fn(),
+  };
+
+  const categoriesService = {
+    findOne: jest.fn(),
+  };
+
+  const mockBudgetDoc = {
+    _id: budgetId,
+    tripId: boardId,
+    categoryId,
+    yearMonth: '2026-07',
+    limit: 50000,
+    currency: 'ARS',
+    save: saveMock,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BoardMonthBudgetsService,
+        {
+          provide: getModelToken(BoardMonthBudget.name),
+          useValue: BudgetModelMock,
+        },
+        { provide: getModelToken(Expense.name), useValue: expenseModel },
+        { provide: ParticipantsService, useValue: participantsService },
+        { provide: BoardsService, useValue: boardsService },
+        { provide: CategoriesService, useValue: categoriesService },
+      ],
+    }).compile();
+
+    service = module.get(BoardMonthBudgetsService);
+    participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+    boardsService.assertEverydayFeatures.mockResolvedValue({
+      _id: boardId,
+      baseCurrency: 'ARS',
+      type: 'everyday',
+    });
+    boardsService.findByIdOrFail.mockResolvedValue({
+      _id: boardId,
+      baseCurrency: 'ARS',
+    });
+    categoriesService.findOne.mockResolvedValue({
+      _id: categoryId,
+      tripId: boardId,
+      name: 'Comida',
+    });
+    budgetQuery.findOne.mockResolvedValue(null);
+  });
+
+  describe('create', () => {
+    it('should create a monthly budget for an everyday board', async () => {
+      saveMock.mockResolvedValue({
+        _id: budgetId,
+        limit: 50000,
+        yearMonth: '2026-07',
+      });
+
+      const result = await service.create(
+        {
+          boardId: boardId.toString(),
+          categoryId: categoryId.toString(),
+          yearMonth: '2026-07',
+          limit: 50000,
+        },
+        userId,
+      );
+
+      expect(boardsService.assertEverydayFeatures).toHaveBeenCalledWith(
+        boardId.toString(),
+      );
+      expect(categoriesService.findOne).toHaveBeenCalledWith(
+        categoryId.toString(),
+        userId,
+      );
+      expect(BudgetModelMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 50000,
+          yearMonth: '2026-07',
+          currency: 'ARS',
+        }),
+      );
+      expect(saveMock).toHaveBeenCalled();
+      expect(result.limit).toBe(50000);
+    });
+
+    it('should reject duplicate budget for same category and month', async () => {
+      budgetQuery.findOne.mockResolvedValue({ _id: budgetId });
+
+      await expect(
+        service.create(
+          {
+            boardId: boardId.toString(),
+            categoryId: categoryId.toString(),
+            yearMonth: '2026-07',
+            limit: 50000,
+          },
+          userId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject when category belongs to another board', async () => {
+      categoriesService.findOne.mockResolvedValue({
+        _id: categoryId,
+        tripId: new Types.ObjectId(),
+      });
+
+      await expect(
+        service.create(
+          {
+            boardId: boardId.toString(),
+            categoryId: categoryId.toString(),
+            yearMonth: '2026-07',
+            limit: 50000,
+          },
+          userId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject create on travel boards', async () => {
+      boardsService.assertEverydayFeatures.mockRejectedValue(
+        new ForbiddenException(
+          'Esta operación solo está disponible en tableros de tipo everyday',
+        ),
+      );
+
+      await expect(
+        service.create(
+          {
+            boardId: boardId.toString(),
+            categoryId: categoryId.toString(),
+            yearMonth: '2026-07',
+            limit: 50000,
+          },
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('should require boardId', async () => {
+      await expect(
+        service.create(
+          {
+            categoryId: categoryId.toString(),
+            yearMonth: '2026-07',
+            limit: 50000,
+          } as never,
+          userId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getProgress', () => {
+    it('should calculate spent and percentUsed from categorized expenses', async () => {
+      const chain = {
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([
+          {
+            _id: budgetId,
+            tripId: boardId,
+            categoryId,
+            yearMonth: '2026-07',
+            limit: 10000,
+            currency: 'ARS',
+          },
+        ]),
+      };
+      budgetQuery.find.mockReturnValue(chain);
+
+      expenseModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            categoryId,
+            amount: 2500,
+            currency: 'ARS',
+            expenseDate: new Date('2026-07-10'),
+          },
+          {
+            categoryId,
+            amount: 1500,
+            currency: 'ARS',
+            expenseDate: new Date('2026-07-20'),
+          },
+          {
+            categoryId,
+            amount: 500,
+            currency: 'USD',
+            expenseDate: new Date('2026-07-21'),
+          },
+        ]),
+      });
+
+      const progress = await service.getProgress(
+        boardId.toString(),
+        '2026-07',
+        userId,
+      );
+
+      expect(progress).toHaveLength(1);
+      expect(progress[0].spent).toBe(4000);
+      expect(progress[0].limit).toBe(10000);
+      expect(progress[0].remaining).toBe(6000);
+      expect(progress[0].percentUsed).toBe(40);
+    });
+
+    it('should return empty list when no budgets exist', async () => {
+      const chain = {
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([]),
+      };
+      budgetQuery.find.mockReturnValue(chain);
+
+      const progress = await service.getProgress(
+        boardId.toString(),
+        '2026-07',
+        userId,
+      );
+
+      expect(progress).toEqual([]);
+      expect(expenseModel.find).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return progress for a single budget', async () => {
+      budgetQuery.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          _id: budgetId,
+          tripId: boardId,
+          categoryId,
+          yearMonth: '2026-07',
+          limit: 20000,
+          currency: 'ARS',
+        }),
+      });
+
+      expenseModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            categoryId,
+            amount: 5000,
+            currency: 'ARS',
+            expenseDate: new Date('2026-07-05'),
+          },
+        ]),
+      });
+
+      const result = await service.findOne(budgetId.toString(), userId);
+
+      expect(result.spent).toBe(5000);
+      expect(result.percentUsed).toBe(25);
+    });
+
+    it('should throw when budget not found', async () => {
+      budgetQuery.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.findOne(budgetId.toString(), userId),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update limit without clearing other fields', async () => {
+      budgetQuery.findById.mockResolvedValue(mockBudgetDoc);
+      saveMock.mockResolvedValue({ ...mockBudgetDoc, limit: 75000 });
+
+      const result = await service.update(
+        budgetId.toString(),
+        { limit: 75000 },
+        userId,
+      );
+
+      expect(mockBudgetDoc.limit).toBe(75000);
+      expect(saveMock).toHaveBeenCalled();
+      expect(result.limit).toBe(75000);
+    });
+
+    it('should reject update on travel boards', async () => {
+      budgetQuery.findById.mockResolvedValue(mockBudgetDoc);
+      boardsService.assertEverydayFeatures.mockRejectedValue(
+        new ForbiddenException('everyday only'),
+      );
+
+      await expect(
+        service.update(budgetId.toString(), { limit: 100 }, userId),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete budget after access checks', async () => {
+      budgetQuery.findById.mockResolvedValue(mockBudgetDoc);
+      budgetQuery.findByIdAndDelete.mockResolvedValue(mockBudgetDoc);
+
+      await service.remove(budgetId.toString(), userId);
+
+      expect(budgetQuery.findByIdAndDelete).toHaveBeenCalledWith(
+        budgetId.toString(),
+      );
+    });
+  });
+});

--- a/src/board-month-budgets/board-month-budgets.service.ts
+++ b/src/board-month-budgets/board-month-budgets.service.ts
@@ -1,0 +1,258 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import {
+  BoardMonthBudget,
+  BoardMonthBudgetDocument,
+} from './board-month-budget.schema';
+import { Expense, ExpenseDocument } from '../expenses/expense.schema';
+import { CreateBoardMonthBudgetDto } from './dto/create-board-month-budget.dto';
+import { UpdateBoardMonthBudgetDto } from './dto/update-board-month-budget.dto';
+import { ParticipantsService } from '../participants/participants.service';
+import { BoardsService } from '../trips/trips.service';
+import { CategoriesService } from '../categories/categories.service';
+import { resolveBoardId } from '../common/utils/resolve-board-id';
+import { parseYearMonth } from '../common/utils/parse-year-month';
+import { DEFAULT_CURRENCY } from '../common/constants/currencies';
+
+export interface BoardMonthBudgetProgress {
+  budgetId: string;
+  boardId: string;
+  categoryId: string;
+  yearMonth: string;
+  limit: number;
+  spent: number;
+  remaining: number;
+  percentUsed: number;
+  currency: string;
+}
+
+type BoardMonthBudgetRecord = BoardMonthBudget & { _id: Types.ObjectId };
+
+function parseDateFrom(value: string): Date {
+  return new Date(value);
+}
+
+@Injectable()
+export class BoardMonthBudgetsService {
+  private readonly logger = new Logger(BoardMonthBudgetsService.name);
+
+  constructor(
+    @InjectModel(BoardMonthBudget.name)
+    private boardMonthBudgetModel: Model<BoardMonthBudgetDocument>,
+    @InjectModel(Expense.name)
+    private expenseModel: Model<ExpenseDocument>,
+    private participantsService: ParticipantsService,
+    private boardsService: BoardsService,
+    private categoriesService: CategoriesService,
+  ) {}
+
+  async create(
+    createDto: CreateBoardMonthBudgetDto,
+    userId: string,
+  ): Promise<BoardMonthBudget> {
+    const boardId = resolveBoardId(createDto);
+    if (!boardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+    const board = await this.boardsService.assertEverydayFeatures(boardId);
+
+    const category = await this.categoriesService.findOne(
+      createDto.categoryId,
+      userId,
+    );
+    if (category.tripId.toString() !== boardId) {
+      throw new BadRequestException('La categoría no pertenece a este tablero');
+    }
+
+    parseYearMonth(createDto.yearMonth);
+
+    const existing = await this.boardMonthBudgetModel.findOne({
+      tripId: new Types.ObjectId(boardId),
+      categoryId: new Types.ObjectId(createDto.categoryId),
+      yearMonth: createDto.yearMonth,
+    });
+
+    if (existing) {
+      throw new BadRequestException(
+        'Ya existe un presupuesto mensual para esta categoría en ese mes',
+      );
+    }
+
+    const budget = new this.boardMonthBudgetModel({
+      tripId: new Types.ObjectId(boardId),
+      categoryId: new Types.ObjectId(createDto.categoryId),
+      yearMonth: createDto.yearMonth,
+      limit: createDto.limit,
+      currency: createDto.currency ?? board.baseCurrency ?? DEFAULT_CURRENCY,
+      createdBy: new Types.ObjectId(userId),
+    });
+
+    const saved = await budget.save();
+    this.logger.log(
+      `Board month budget created: ${saved._id.toString()} on board ${boardId}`,
+    );
+    return saved;
+  }
+
+  async findAllByBoardAndMonth(
+    boardId: string,
+    yearMonth: string,
+    userId: string,
+  ): Promise<BoardMonthBudgetProgress[]> {
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+    await this.boardsService.assertEverydayFeatures(boardId);
+
+    parseYearMonth(yearMonth);
+
+    const budgets = await this.boardMonthBudgetModel
+      .find({
+        tripId: new Types.ObjectId(boardId),
+        yearMonth,
+      })
+      .sort({ createdAt: 1 })
+      .lean();
+
+    return this.attachProgress(boardId, yearMonth, budgets);
+  }
+
+  async getProgress(
+    boardId: string,
+    yearMonth: string,
+    userId: string,
+  ): Promise<BoardMonthBudgetProgress[]> {
+    return this.findAllByBoardAndMonth(boardId, yearMonth, userId);
+  }
+
+  async findOne(id: string, userId: string): Promise<BoardMonthBudgetProgress> {
+    const budget = await this.boardMonthBudgetModel.findById(id).lean();
+
+    if (!budget) {
+      throw new NotFoundException('Presupuesto mensual no encontrado');
+    }
+
+    const boardId = budget.tripId.toString();
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+    await this.boardsService.assertEverydayFeatures(boardId);
+
+    const [progress] = await this.attachProgress(boardId, budget.yearMonth, [
+      budget,
+    ]);
+    return progress;
+  }
+
+  async update(
+    id: string,
+    updateDto: UpdateBoardMonthBudgetDto,
+    userId: string,
+  ): Promise<BoardMonthBudget> {
+    const budget = await this.boardMonthBudgetModel.findById(id);
+
+    if (!budget) {
+      throw new NotFoundException('Presupuesto mensual no encontrado');
+    }
+
+    const boardId = budget.tripId.toString();
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+    await this.boardsService.assertEverydayFeatures(boardId);
+
+    if (updateDto.limit !== undefined) {
+      budget.limit = updateDto.limit;
+    }
+    if (updateDto.currency !== undefined) {
+      budget.currency = updateDto.currency;
+    }
+
+    budget.updatedAt = new Date();
+    const saved = await budget.save();
+    this.logger.log(`Board month budget updated: ${id}`);
+    return saved;
+  }
+
+  async remove(id: string, userId: string): Promise<void> {
+    const budget = await this.boardMonthBudgetModel.findById(id);
+
+    if (!budget) {
+      throw new NotFoundException('Presupuesto mensual no encontrado');
+    }
+
+    await this.participantsService.ensureParticipantAccess(
+      budget.tripId.toString(),
+      userId,
+    );
+    await this.boardsService.assertEverydayFeatures(budget.tripId.toString());
+
+    await this.boardMonthBudgetModel.findByIdAndDelete(id);
+    this.logger.log(`Board month budget deleted: ${id}`);
+  }
+
+  private async attachProgress(
+    boardId: string,
+    yearMonth: string,
+    budgets: BoardMonthBudgetRecord[],
+  ): Promise<BoardMonthBudgetProgress[]> {
+    if (budgets.length === 0) {
+      return [];
+    }
+
+    const board = await this.boardsService.findByIdOrFail(boardId);
+    const boardCurrency = board.baseCurrency ?? DEFAULT_CURRENCY;
+    const { from, toExclusive } = parseYearMonth(yearMonth);
+    const dateFilter = {
+      $gte: parseDateFrom(from),
+      $lt: parseDateFrom(toExclusive),
+    };
+
+    const categoryIds = budgets.map((b) => b.categoryId);
+    const expenses = await this.expenseModel
+      .find({
+        tripId: new Types.ObjectId(boardId),
+        categoryId: { $in: categoryIds },
+        expenseDate: dateFilter,
+      })
+      .lean();
+
+    const spentByCategory = new Map<string, number>();
+    for (const expense of expenses) {
+      if (expense.currency !== boardCurrency) {
+        continue;
+      }
+      const key = expense.categoryId?.toString();
+      if (!key) {
+        continue;
+      }
+      spentByCategory.set(
+        key,
+        (spentByCategory.get(key) ?? 0) + expense.amount,
+      );
+    }
+
+    return budgets.map((budget) => {
+      const categoryKey = budget.categoryId.toString();
+      const spent = spentByCategory.get(categoryKey) ?? 0;
+      const limit = budget.limit;
+      const remaining = limit - spent;
+      const percentUsed =
+        limit > 0 ? Math.round((spent / limit) * 10000) / 100 : 0;
+
+      return {
+        budgetId: budget._id.toString(),
+        boardId,
+        categoryId: categoryKey,
+        yearMonth: budget.yearMonth,
+        limit,
+        spent,
+        remaining,
+        percentUsed,
+        currency: budget.currency,
+      };
+    });
+  }
+}

--- a/src/board-month-budgets/board-month-budgets.service.ts
+++ b/src/board-month-budgets/board-month-budgets.service.ts
@@ -91,7 +91,7 @@ export class BoardMonthBudgetsService {
       categoryId: new Types.ObjectId(createDto.categoryId),
       yearMonth: createDto.yearMonth,
       limit: createDto.limit,
-      currency: createDto.currency ?? board.baseCurrency ?? DEFAULT_CURRENCY,
+      currency: board.baseCurrency ?? DEFAULT_CURRENCY,
       createdBy: new Types.ObjectId(userId),
     });
 
@@ -165,9 +165,6 @@ export class BoardMonthBudgetsService {
 
     if (updateDto.limit !== undefined) {
       budget.limit = updateDto.limit;
-    }
-    if (updateDto.currency !== undefined) {
-      budget.currency = updateDto.currency;
     }
 
     budget.updatedAt = new Date();
@@ -251,7 +248,7 @@ export class BoardMonthBudgetsService {
         spent,
         remaining,
         percentUsed,
-        currency: budget.currency,
+        currency: boardCurrency,
       };
     });
   }

--- a/src/board-month-budgets/dto/create-board-month-budget.dto.ts
+++ b/src/board-month-budgets/dto/create-board-month-budget.dto.ts
@@ -1,0 +1,43 @@
+import {
+  IsNotEmpty,
+  IsString,
+  IsNumber,
+  Min,
+  IsOptional,
+  IsMongoId,
+  ValidateIf,
+  Matches,
+} from 'class-validator';
+
+const YEAR_MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+export class CreateBoardMonthBudgetDto {
+  @ValidateIf((o: CreateBoardMonthBudgetDto) => !o.tripId)
+  @IsNotEmpty({ message: 'boardId o tripId es requerido' })
+  @IsMongoId({ message: 'El ID del tablero no es válido' })
+  boardId?: string;
+
+  @ValidateIf((o: CreateBoardMonthBudgetDto) => !o.boardId)
+  @IsNotEmpty({ message: 'boardId o tripId es requerido' })
+  @IsMongoId({ message: 'El ID del tablero no es válido' })
+  tripId?: string;
+
+  @IsNotEmpty({ message: 'categoryId es requerido' })
+  @IsMongoId({ message: 'El ID de la categoría no es válido' })
+  categoryId: string;
+
+  @IsNotEmpty({ message: 'yearMonth es requerido' })
+  @IsString({ message: 'yearMonth debe ser texto' })
+  @Matches(YEAR_MONTH_PATTERN, {
+    message: 'yearMonth debe tener formato YYYY-MM (ej. 2026-07)',
+  })
+  yearMonth: string;
+
+  @IsNumber({}, { message: 'limit debe ser un número' })
+  @Min(0, { message: 'limit no puede ser negativo' })
+  limit: number;
+
+  @IsOptional()
+  @IsString({ message: 'currency debe ser texto' })
+  currency?: string;
+}

--- a/src/board-month-budgets/dto/create-board-month-budget.dto.ts
+++ b/src/board-month-budgets/dto/create-board-month-budget.dto.ts
@@ -3,7 +3,6 @@ import {
   IsString,
   IsNumber,
   Min,
-  IsOptional,
   IsMongoId,
   ValidateIf,
   Matches,
@@ -36,8 +35,4 @@ export class CreateBoardMonthBudgetDto {
   @IsNumber({}, { message: 'limit debe ser un número' })
   @Min(0, { message: 'limit no puede ser negativo' })
   limit: number;
-
-  @IsOptional()
-  @IsString({ message: 'currency debe ser texto' })
-  currency?: string;
 }

--- a/src/board-month-budgets/dto/update-board-month-budget.dto.ts
+++ b/src/board-month-budgets/dto/update-board-month-budget.dto.ts
@@ -1,0 +1,12 @@
+import { IsNumber, Min, IsOptional, IsString } from 'class-validator';
+
+export class UpdateBoardMonthBudgetDto {
+  @IsOptional()
+  @IsNumber({}, { message: 'limit debe ser un número' })
+  @Min(0, { message: 'limit no puede ser negativo' })
+  limit?: number;
+
+  @IsOptional()
+  @IsString({ message: 'currency debe ser texto' })
+  currency?: string;
+}

--- a/src/board-month-budgets/dto/update-board-month-budget.dto.ts
+++ b/src/board-month-budgets/dto/update-board-month-budget.dto.ts
@@ -1,12 +1,8 @@
-import { IsNumber, Min, IsOptional, IsString } from 'class-validator';
+import { IsNumber, Min, IsOptional } from 'class-validator';
 
 export class UpdateBoardMonthBudgetDto {
   @IsOptional()
   @IsNumber({}, { message: 'limit debe ser un número' })
   @Min(0, { message: 'limit no puede ser negativo' })
   limit?: number;
-
-  @IsOptional()
-  @IsString({ message: 'currency debe ser texto' })
-  currency?: string;
 }

--- a/src/trips/boards.service.spec.ts
+++ b/src/trips/boards.service.spec.ts
@@ -233,6 +233,50 @@ describe('BoardsService', () => {
     });
   });
 
+  describe('assertEverydayFeatures', () => {
+    it('should allow everyday boards', async () => {
+      boardModel.findById.mockResolvedValue({
+        _id: boardId,
+        type: BoardType.EVERYDAY,
+      });
+      await expect(
+        service.assertEverydayFeatures(boardId.toString()),
+      ).resolves.toBeDefined();
+    });
+
+    it('should reject travel boards', async () => {
+      boardModel.findById.mockResolvedValue({
+        _id: boardId,
+        type: BoardType.TRAVEL,
+      });
+      await expect(
+        service.assertEverydayFeatures(boardId.toString()),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('isEverydayBoard', () => {
+    it('should return true for everyday boards', async () => {
+      boardModel.findById.mockResolvedValue({
+        _id: boardId,
+        type: BoardType.EVERYDAY,
+      });
+      await expect(service.isEverydayBoard(boardId.toString())).resolves.toBe(
+        true,
+      );
+    });
+
+    it('should return false for travel boards', async () => {
+      boardModel.findById.mockResolvedValue({
+        _id: boardId,
+        type: BoardType.TRAVEL,
+      });
+      await expect(service.isEverydayBoard(boardId.toString())).resolves.toBe(
+        false,
+      );
+    });
+  });
+
   describe('update type immutability', () => {
     it('should reject changing board type', async () => {
       participantModel.findOne.mockResolvedValue({

--- a/src/trips/trips.service.ts
+++ b/src/trips/trips.service.ts
@@ -160,9 +160,26 @@ export class BoardsService implements OnModuleInit {
     return board;
   }
 
+  async assertEverydayFeatures(boardId: string): Promise<BoardDocument> {
+    const board = await this.findByIdOrFail(boardId);
+
+    if (board.type !== BoardType.EVERYDAY) {
+      throw new ForbiddenException(
+        'Esta operación solo está disponible en tableros de tipo everyday',
+      );
+    }
+
+    return board;
+  }
+
   async isTravelBoard(boardId: string): Promise<boolean> {
     const board = await this.findByIdOrFail(boardId);
     return board.type === BoardType.TRAVEL;
+  }
+
+  async isEverydayBoard(boardId: string): Promise<boolean> {
+    const board = await this.findByIdOrFail(boardId);
+    return board.type === BoardType.EVERYDAY;
   }
 
   async update(


### PR DESCRIPTION
## Summary

- Nuevo módulo `board-month-budgets` con entidad `BoardMonthBudget` (boardId, categoryId, yearMonth, limit).
- CRUD bajo `/api/board-month-budgets` restringido a tableros `everyday`, con gate `assertEverydayFeatures`.
- Endpoints de progreso (`GET /board-month-budgets/progress` y listado con `yearMonth`) calculan `spent`, `remaining` y `percentUsed` desde gastos categorizados del mes calendario (moneda base del tablero).
- Los presupuestos travel existentes (`/api/budgets`) no se modifican.

Closes #7

## Self-review (Developer)

- Commit: `c6ffd293bbbe20ada9a98fc1c9c9439a340cc284`
- Bugbot: 1 finding medium resuelto (moneda de progreso alineada con `baseCurrency` del tablero)
- Security: sin issues

## Cómo probarlo

1. Levantar backend: `npm run start:dev` (MongoDB + `.env` con `MONGODB_URI` y JWT).
2. Autenticarse y crear/obtener un tablero `everyday` con categorías seed.
3. `POST /api/board-month-budgets` con body:
   ```json
   {
     "boardId": "<everyday-board-id>",
     "categoryId": "<comida-category-id>",
     "yearMonth": "2026-08",
     "limit": 100000
   }
   ```
4. Registrar gastos en esa categoría con `expenseDate` en agosto 2026 (`POST /api/expenses`).
5. `GET /api/board-month-budgets/progress?boardId=<id>&yearMonth=2026-08` → `spent`, `percentUsed` y `remaining` coherentes con los gastos.
6. Verificar que `GET/POST /api/budgets` en un tablero `travel` sigue funcionando igual que antes.

## Requiere antes de deploy

Ninguno (índices Mongoose se crean al arrancar).

## Notas para el reviewer

- `spent` solo suma gastos en la moneda base del tablero (mismo criterio que `incomes/summary` hasta FX en #9).
- Índice único `{ tripId, categoryId, yearMonth }` evita duplicados por categoría/mes.