### PR TITLE
[Issue #8] Reportes: mes calendario, ciclo TC, por categoría, consolidado

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { CategoriesModule } from './categories/categories.module';
 import { PaymentMethodsModule } from './payment-methods/payment-methods.module';
 import { IncomesModule } from './incomes/incomes.module';
 import { BoardMonthBudgetsModule } from './board-month-budgets/board-month-budgets.module';
+import { ReportsModule } from './reports/reports.module';
 
 @Module({
   imports: [
@@ -53,6 +54,7 @@ import { BoardMonthBudgetsModule } from './board-month-budgets/board-month-budge
     PaymentMethodsModule,
     IncomesModule,
     BoardMonthBudgetsModule,
+    ReportsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/utils/credit-cycle.spec.ts
+++ b/src/common/utils/credit-cycle.spec.ts
@@ -1,0 +1,74 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  getCreditCycleRange,
+  getCurrentCycleClosingMonth,
+  resolveCycleClosingMonth,
+  listRecentCycleLabels,
+} from './credit-cycle';
+
+describe('credit-cycle', () => {
+  describe('resolveCycleClosingMonth', () => {
+    it('should assign expense on closing day to that month cycle', () => {
+      expect(
+        resolveCycleClosingMonth(new Date('2026-08-14T12:00:00.000Z'), 14),
+      ).toBe('2026-08');
+    });
+
+    it('should assign expense after closing day to next month cycle', () => {
+      expect(
+        resolveCycleClosingMonth(new Date('2026-08-15T12:00:00.000Z'), 14),
+      ).toBe('2026-09');
+    });
+
+    it('should roll December into January next year', () => {
+      expect(
+        resolveCycleClosingMonth(new Date('2026-12-20T12:00:00.000Z'), 14),
+      ).toBe('2027-01');
+    });
+  });
+
+  describe('getCreditCycleRange', () => {
+    it('should return Jul 15–Aug 14 for August 2026 cycle with closingDay 14', () => {
+      expect(getCreditCycleRange('2026-08', 14)).toEqual({
+        from: '2026-07-15',
+        toExclusive: '2026-08-15',
+        periodToInclusive: '2026-08-14',
+        cycleLabel: '2026-08',
+      });
+    });
+
+    it('should handle January cycle crossing year boundary', () => {
+      expect(getCreditCycleRange('2027-01', 14)).toEqual({
+        from: '2026-12-15',
+        toExclusive: '2027-01-15',
+        periodToInclusive: '2027-01-14',
+        cycleLabel: '2027-01',
+      });
+    });
+  });
+
+  describe('getCurrentCycleClosingMonth', () => {
+    it('should resolve current cycle from reference date', () => {
+      expect(
+        getCurrentCycleClosingMonth(14, new Date('2026-08-01T00:00:00.000Z')),
+      ).toBe('2026-08');
+    });
+  });
+
+  describe('listRecentCycleLabels', () => {
+    it('should return descending recent labels', () => {
+      const labels = listRecentCycleLabels(
+        14,
+        3,
+        new Date('2026-08-01T00:00:00.000Z'),
+      );
+      expect(labels).toEqual(['2026-08', '2026-07', '2026-06']);
+    });
+  });
+
+  it('should reject invalid closingDay', () => {
+    expect(() => getCreditCycleRange('2026-08', 31)).toThrow(
+      BadRequestException,
+    );
+  });
+});

--- a/src/common/utils/credit-cycle.ts
+++ b/src/common/utils/credit-cycle.ts
@@ -1,0 +1,133 @@
+import { BadRequestException } from '@nestjs/common';
+
+const YEAR_MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+export interface CreditCycleRange {
+  /** Inclusive start date (YYYY-MM-DD). */
+  from: string;
+  /** Exclusive end boundary for queries (YYYY-MM-DD). */
+  toExclusive: string;
+  /** Inclusive end date (YYYY-MM-DD). */
+  periodToInclusive: string;
+  /** Closing month label (YYYY-MM). */
+  cycleLabel: string;
+}
+
+function padMonth(month: number): string {
+  return String(month).padStart(2, '0');
+}
+
+function padDay(day: number): string {
+  return String(day).padStart(2, '0');
+}
+
+function addUtcDays(dateStr: string, days: number): string {
+  const date = new Date(`${dateStr}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+export function assertValidClosingDay(closingDay: number): void {
+  if (!Number.isInteger(closingDay) || closingDay < 1 || closingDay > 28) {
+    throw new BadRequestException('closingDay debe ser un entero entre 1 y 28');
+  }
+}
+
+export function assertValidCycleLabel(cycleLabel: string): void {
+  if (!YEAR_MONTH_PATTERN.test(cycleLabel)) {
+    throw new BadRequestException(
+      'cycle debe ser "current" o YYYY-MM (mes de cierre del ciclo)',
+    );
+  }
+}
+
+/**
+ * Returns the closing-month label (YYYY-MM) for an expense in a credit cycle.
+ * Example: closingDay=14, expense on 2026-08-10 → cycle 2026-08 (Jul 15–Aug 14).
+ */
+export function resolveCycleClosingMonth(
+  expenseDate: Date,
+  closingDay: number,
+): string {
+  assertValidClosingDay(closingDay);
+
+  const year = expenseDate.getUTCFullYear();
+  const month = expenseDate.getUTCMonth() + 1;
+  const day = expenseDate.getUTCDate();
+
+  if (day <= closingDay) {
+    return `${year}-${padMonth(month)}`;
+  }
+
+  if (month === 12) {
+    return `${year + 1}-01`;
+  }
+
+  return `${year}-${padMonth(month + 1)}`;
+}
+
+export function getCurrentCycleClosingMonth(
+  closingDay: number,
+  referenceDate: Date = new Date(),
+): string {
+  return resolveCycleClosingMonth(referenceDate, closingDay);
+}
+
+/**
+ * Date range for a credit card billing cycle that closes on closingDay of cycleLabel month.
+ */
+export function getCreditCycleRange(
+  cycleLabel: string,
+  closingDay: number,
+): CreditCycleRange {
+  assertValidCycleLabel(cycleLabel);
+  assertValidClosingDay(closingDay);
+
+  const [yearStr, monthStr] = cycleLabel.split('-');
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+
+  let prevMonth = month - 1;
+  let prevYear = year;
+  if (prevMonth === 0) {
+    prevMonth = 12;
+    prevYear = year - 1;
+  }
+
+  const from = `${prevYear}-${padMonth(prevMonth)}-${padDay(closingDay + 1)}`;
+  const periodToInclusive = `${year}-${padMonth(month)}-${padDay(closingDay)}`;
+  const toExclusive = addUtcDays(periodToInclusive, 1);
+
+  return {
+    from,
+    toExclusive,
+    periodToInclusive,
+    cycleLabel,
+  };
+}
+
+/** Last N closing-month labels ending at the current cycle (inclusive). */
+export function listRecentCycleLabels(
+  closingDay: number,
+  count: number,
+  referenceDate: Date = new Date(),
+): string[] {
+  assertValidClosingDay(closingDay);
+
+  const labels: string[] = [];
+  let cursor = getCurrentCycleClosingMonth(closingDay, referenceDate);
+
+  for (let i = 0; i < count; i += 1) {
+    labels.push(cursor);
+    const [yearStr, monthStr] = cursor.split('-');
+    let year = Number(yearStr);
+    let month = Number(monthStr) - 1;
+    if (month === 0) {
+      month = 12;
+      year -= 1;
+    }
+    cursor = `${year}-${padMonth(month)}`;
+  }
+
+  return labels;
+}

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { ReportsService } from './reports.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GetUser } from '../auth/decorators/get-user.decorator';
+import { UserDocument } from '../users/user.schema';
+
+@Controller('reports')
+@UseGuards(JwtAuthGuard)
+export class ReportsController {
+  constructor(private readonly reportsService: ReportsService) {}
+
+  @Get('board')
+  async getBoardCalendarReport(
+    @Query('boardId') boardId: string,
+    @Query('yearMonth') yearMonth: string,
+    @GetUser() user: UserDocument,
+    @Query('tripId') tripId?: string,
+  ) {
+    const resolvedBoardId = boardId || tripId;
+    if (!resolvedBoardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+    if (!yearMonth) {
+      throw new BadRequestException('yearMonth es requerido (formato YYYY-MM)');
+    }
+
+    const report = await this.reportsService.getBoardCalendarReport(
+      resolvedBoardId,
+      yearMonth,
+      user._id.toString(),
+    );
+
+    return { report };
+  }
+
+  @Get('board/credit-cycle')
+  async getCreditCycleReport(
+    @Query('boardId') boardId: string,
+    @Query('paymentMethodId') paymentMethodId: string,
+    @GetUser() user: UserDocument,
+    @Query('cycle') cycle = 'current',
+    @Query('tripId') tripId?: string,
+  ) {
+    const resolvedBoardId = boardId || tripId;
+    if (!resolvedBoardId) {
+      throw new BadRequestException('boardId o tripId es requerido');
+    }
+    if (!paymentMethodId) {
+      throw new BadRequestException('paymentMethodId es requerido');
+    }
+
+    const report = await this.reportsService.getCreditCycleReport(
+      resolvedBoardId,
+      paymentMethodId,
+      cycle,
+      user._id.toString(),
+    );
+
+    return { report };
+  }
+
+  @Get('consolidated')
+  async getConsolidatedReport(
+    @Query('yearMonth') yearMonth: string,
+    @GetUser() user: UserDocument,
+    @Query('boardIds') boardIdsParam?: string,
+  ) {
+    if (!yearMonth) {
+      throw new BadRequestException('yearMonth es requerido (formato YYYY-MM)');
+    }
+
+    const boardIds = boardIdsParam
+      ? boardIdsParam
+          .split(',')
+          .map((id) => id.trim())
+          .filter(Boolean)
+      : undefined;
+
+    const report = await this.reportsService.getConsolidatedReport(
+      yearMonth,
+      user._id.toString(),
+      boardIds,
+    );
+
+    return { report };
+  }
+}

--- a/src/reports/reports.module.ts
+++ b/src/reports/reports.module.ts
@@ -1,0 +1,32 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ReportsService } from './reports.service';
+import { ReportsController } from './reports.controller';
+import { Expense, ExpenseSchema } from '../expenses/expense.schema';
+import { Income, IncomeSchema } from '../incomes/income.schema';
+import { Category, CategorySchema } from '../categories/category.schema';
+import {
+  PaymentMethod,
+  PaymentMethodSchema,
+} from '../payment-methods/payment-method.schema';
+import { ParticipantsModule } from '../participants/participants.module';
+import { BoardsModule } from '../trips/trips.module';
+import { PaymentMethodsModule } from '../payment-methods/payment-methods.module';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Expense.name, schema: ExpenseSchema },
+      { name: Income.name, schema: IncomeSchema },
+      { name: Category.name, schema: CategorySchema },
+      { name: PaymentMethod.name, schema: PaymentMethodSchema },
+    ]),
+    forwardRef(() => ParticipantsModule),
+    forwardRef(() => BoardsModule),
+    forwardRef(() => PaymentMethodsModule),
+  ],
+  controllers: [ReportsController],
+  providers: [ReportsService],
+  exports: [ReportsService],
+})
+export class ReportsModule {}

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -1,0 +1,324 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { Types } from 'mongoose';
+import { ForbiddenBoardAccessError, ReportsService } from './reports.service';
+import { Expense } from '../expenses/expense.schema';
+import { Income } from '../incomes/income.schema';
+import { Category } from '../categories/category.schema';
+import {
+  PaymentMethod,
+  PaymentMethodKind,
+} from '../payment-methods/payment-method.schema';
+import { ParticipantsService } from '../participants/participants.service';
+import { BoardsService } from '../trips/trips.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+
+describe('ReportsService', () => {
+  let service: ReportsService;
+
+  const boardId = new Types.ObjectId();
+  const userId = new Types.ObjectId().toString();
+  const categoryId = new Types.ObjectId();
+  const paymentMethodId = new Types.ObjectId();
+
+  const expenseModel = { find: jest.fn() };
+  const incomeModel = { find: jest.fn() };
+  const categoryModel = { find: jest.fn() };
+  const paymentMethodModel = { find: jest.fn() };
+
+  const paymentMethodsService = {
+    findAvailableForBoard: jest.fn(),
+  };
+
+  const participantsService = {
+    ensureParticipantAccess: jest.fn(),
+  };
+
+  const boardsService = {
+    findByIdOrFail: jest.fn(),
+    findAll: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportsService,
+        { provide: getModelToken(Expense.name), useValue: expenseModel },
+        { provide: getModelToken(Income.name), useValue: incomeModel },
+        { provide: getModelToken(Category.name), useValue: categoryModel },
+        {
+          provide: getModelToken(PaymentMethod.name),
+          useValue: paymentMethodModel,
+        },
+        { provide: ParticipantsService, useValue: participantsService },
+        { provide: BoardsService, useValue: boardsService },
+        { provide: PaymentMethodsService, useValue: paymentMethodsService },
+      ],
+    }).compile();
+
+    service = module.get(ReportsService);
+    participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+    boardsService.findByIdOrFail.mockResolvedValue({
+      _id: boardId,
+      baseCurrency: 'ARS',
+      name: 'Hogar',
+    });
+  });
+
+  describe('getBoardCalendarReport', () => {
+    it('should return calendar totals and breakdowns', async () => {
+      incomeModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([{ amount: 1000, currency: 'ARS' }]),
+      });
+
+      expenseModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            amount: 200,
+            currency: 'ARS',
+            categoryId,
+            paymentMethodId,
+          },
+          {
+            amount: 50,
+            currency: 'USD',
+            categoryId,
+            paymentMethodId,
+          },
+        ]),
+      });
+
+      categoryModel.find.mockReturnValue({
+        lean: jest
+          .fn()
+          .mockResolvedValue([{ _id: categoryId, name: 'Comida' }]),
+      });
+
+      paymentMethodModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            _id: paymentMethodId,
+            name: 'Visa',
+            kind: PaymentMethodKind.CREDIT,
+          },
+        ]),
+      });
+
+      const report = await service.getBoardCalendarReport(
+        boardId.toString(),
+        '2026-07',
+        userId,
+      );
+
+      expect(report.totalIncomes).toBe(1000);
+      expect(report.totalExpenses).toBe(200);
+      expect(report.remaining).toBe(800);
+      expect(report.byCategory).toEqual([
+        {
+          categoryId: categoryId.toString(),
+          categoryName: 'Comida',
+          total: 200,
+          count: 1,
+        },
+      ]);
+      expect(report.byPaymentMethod[0].paymentMethodName).toBe('Visa');
+      expect(report.excludedDueToCurrencyMismatch).toEqual({
+        incomes: 0,
+        expenses: 1,
+      });
+    });
+
+    it('should require participant access', async () => {
+      participantsService.ensureParticipantAccess.mockRejectedValue(
+        new ForbiddenException('No tienes acceso'),
+      );
+
+      await expect(
+        service.getBoardCalendarReport(boardId.toString(), '2026-07', userId),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('getCreditCycleReport', () => {
+    it('should return closing_day_required when credit card has no closingDay', async () => {
+      paymentMethodsService.findAvailableForBoard.mockResolvedValue([
+        {
+          _id: paymentMethodId,
+          name: 'Visa',
+          kind: PaymentMethodKind.CREDIT,
+          closingDay: undefined,
+        },
+      ]);
+
+      const report = await service.getCreditCycleReport(
+        boardId.toString(),
+        paymentMethodId.toString(),
+        'current',
+        userId,
+      );
+
+      expect(report).toEqual({
+        status: 'closing_day_required',
+        boardId: boardId.toString(),
+        paymentMethodId: paymentMethodId.toString(),
+        paymentMethodName: 'Visa',
+        message:
+          'Configura el día de cierre de esta tarjeta para ver reportes por ciclo de facturación',
+      });
+    });
+
+    it('should return credit cycle totals for configured card', async () => {
+      paymentMethodsService.findAvailableForBoard.mockResolvedValue([
+        {
+          _id: paymentMethodId,
+          name: 'Visa',
+          kind: PaymentMethodKind.CREDIT,
+          closingDay: 14,
+        },
+      ]);
+
+      expenseModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            amount: 300,
+            currency: 'ARS',
+            expenseDate: new Date('2026-08-01T00:00:00.000Z'),
+          },
+        ]),
+      });
+
+      const report = await service.getCreditCycleReport(
+        boardId.toString(),
+        paymentMethodId.toString(),
+        '2026-08',
+        userId,
+      );
+
+      expect(report.status).toBe('ok');
+      if (report.status === 'ok') {
+        expect(report.totalExpenses).toBe(300);
+        expect(report.periodFrom).toBe('2026-07-15');
+        expect(report.periodToInclusive).toBe('2026-08-14');
+        expect(report.availableCycles).toHaveLength(12);
+      }
+    });
+
+    it('should reject non-credit payment methods', async () => {
+      paymentMethodsService.findAvailableForBoard.mockResolvedValue([
+        {
+          _id: paymentMethodId,
+          name: 'Efectivo',
+          kind: PaymentMethodKind.CASH,
+          closingDay: 14,
+        },
+      ]);
+
+      await expect(
+        service.getCreditCycleReport(
+          boardId.toString(),
+          paymentMethodId.toString(),
+          'current',
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should reject payment methods not available for the board', async () => {
+      paymentMethodsService.findAvailableForBoard.mockResolvedValue([]);
+
+      await expect(
+        service.getCreditCycleReport(
+          boardId.toString(),
+          paymentMethodId.toString(),
+          'current',
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('getConsolidatedReport', () => {
+    const board2Id = new Types.ObjectId();
+
+    beforeEach(() => {
+      boardsService.findAll.mockResolvedValue([
+        { _id: boardId, name: 'Hogar', baseCurrency: 'ARS' },
+        { _id: board2Id, name: 'Viaje', baseCurrency: 'USD' },
+      ]);
+    });
+
+    it('should aggregate all user boards by currency', async () => {
+      jest
+        .spyOn(service, 'getBoardCalendarReport')
+        .mockResolvedValueOnce({
+          boardId: boardId.toString(),
+          yearMonth: '2026-07',
+          currency: 'ARS',
+          totalIncomes: 1000,
+          totalExpenses: 400,
+          remaining: 600,
+          byCategory: [],
+          byPaymentMethod: [],
+          excludedDueToCurrencyMismatch: { incomes: 0, expenses: 0 },
+        })
+        .mockResolvedValueOnce({
+          boardId: board2Id.toString(),
+          yearMonth: '2026-07',
+          currency: 'USD',
+          totalIncomes: 500,
+          totalExpenses: 100,
+          remaining: 400,
+          byCategory: [],
+          byPaymentMethod: [],
+          excludedDueToCurrencyMismatch: { incomes: 0, expenses: 0 },
+        });
+
+      const report = await service.getConsolidatedReport('2026-07', userId);
+
+      expect(report.boards).toHaveLength(2);
+      expect(report.totalsByCurrency.ARS).toEqual({
+        totalIncomes: 1000,
+        totalExpenses: 400,
+        remaining: 600,
+        boardCount: 1,
+      });
+      expect(report.totalsByCurrency.USD.boardCount).toBe(1);
+    });
+
+    it('should reject boardIds the user cannot access', async () => {
+      await expect(
+        service.getConsolidatedReport('2026-07', userId, [
+          new Types.ObjectId().toString(),
+        ]),
+      ).rejects.toBeInstanceOf(ForbiddenBoardAccessError);
+    });
+
+    it('should deduplicate repeated boardIds in consolidated report', async () => {
+      const calendarSpy = jest
+        .spyOn(service, 'getBoardCalendarReport')
+        .mockResolvedValue({
+          boardId: boardId.toString(),
+          yearMonth: '2026-07',
+          currency: 'ARS',
+          totalIncomes: 1000,
+          totalExpenses: 400,
+          remaining: 600,
+          byCategory: [],
+          byPaymentMethod: [],
+          excludedDueToCurrencyMismatch: { incomes: 0, expenses: 0 },
+        });
+
+      const report = await service.getConsolidatedReport('2026-07', userId, [
+        boardId.toString(),
+        boardId.toString(),
+      ]);
+
+      expect(calendarSpy).toHaveBeenCalledTimes(1);
+      expect(report.boards).toHaveLength(1);
+      expect(report.totalsByCurrency.ARS.boardCount).toBe(1);
+    });
+  });
+});

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -1,0 +1,479 @@
+import { Injectable, BadRequestException, Logger } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Expense, ExpenseDocument } from '../expenses/expense.schema';
+import { Income, IncomeDocument } from '../incomes/income.schema';
+import { Category, CategoryDocument } from '../categories/category.schema';
+import {
+  PaymentMethod,
+  PaymentMethodDocument,
+  PaymentMethodKind,
+} from '../payment-methods/payment-method.schema';
+import { ParticipantsService } from '../participants/participants.service';
+import { BoardsService } from '../trips/trips.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+import { Board } from '../trips/board.schema';
+import { parseYearMonth } from '../common/utils/parse-year-month';
+import {
+  assertValidCycleLabel,
+  getCreditCycleRange,
+  getCurrentCycleClosingMonth,
+  listRecentCycleLabels,
+  resolveCycleClosingMonth,
+} from '../common/utils/credit-cycle';
+import { DEFAULT_CURRENCY } from '../common/constants/currencies';
+
+export interface CategoryBreakdownItem {
+  categoryId: string | null;
+  categoryName: string;
+  total: number;
+  count: number;
+}
+
+export interface PaymentMethodBreakdownItem {
+  paymentMethodId: string | null;
+  paymentMethodName: string;
+  kind: PaymentMethodKind | null;
+  total: number;
+  count: number;
+}
+
+export interface BoardCalendarReport {
+  boardId: string;
+  yearMonth: string;
+  currency: string;
+  totalIncomes: number;
+  totalExpenses: number;
+  remaining: number;
+  byCategory: CategoryBreakdownItem[];
+  byPaymentMethod: PaymentMethodBreakdownItem[];
+  excludedDueToCurrencyMismatch: {
+    incomes: number;
+    expenses: number;
+  };
+}
+
+export interface CreditCycleReport {
+  status: 'ok';
+  boardId: string;
+  paymentMethodId: string;
+  paymentMethodName: string;
+  closingDay: number;
+  cycleLabel: string;
+  periodFrom: string;
+  periodToInclusive: string;
+  currency: string;
+  totalExpenses: number;
+  expenseCount: number;
+  availableCycles: string[];
+}
+
+export interface CreditCycleClosingDayRequired {
+  status: 'closing_day_required';
+  boardId: string;
+  paymentMethodId: string;
+  paymentMethodName: string;
+  message: string;
+}
+
+export interface ConsolidatedBoardSummary {
+  boardId: string;
+  boardName: string;
+  currency: string;
+  totalIncomes: number;
+  totalExpenses: number;
+  remaining: number;
+}
+
+export interface CurrencyTotals {
+  totalIncomes: number;
+  totalExpenses: number;
+  remaining: number;
+  boardCount: number;
+}
+
+export interface ConsolidatedReport {
+  yearMonth: string;
+  boards: ConsolidatedBoardSummary[];
+  totalsByCurrency: Record<string, CurrencyTotals>;
+}
+
+function parseDateFrom(value: string): Date {
+  return new Date(value);
+}
+
+type BoardListItem = Board & { _id: Types.ObjectId };
+
+function getBoardId(board: BoardListItem): string {
+  return board._id.toString();
+}
+
+function resolveExpensePaymentMethodId(
+  expense: Pick<Expense, 'paymentMethodId' | 'cardId'>,
+): string | null {
+  const id = expense.paymentMethodId ?? expense.cardId;
+  return id ? id.toString() : null;
+}
+
+@Injectable()
+export class ReportsService {
+  private readonly logger = new Logger(ReportsService.name);
+
+  constructor(
+    @InjectModel(Expense.name)
+    private expenseModel: Model<ExpenseDocument>,
+    @InjectModel(Income.name)
+    private incomeModel: Model<IncomeDocument>,
+    @InjectModel(Category.name)
+    private categoryModel: Model<CategoryDocument>,
+    @InjectModel(PaymentMethod.name)
+    private paymentMethodModel: Model<PaymentMethodDocument>,
+    private participantsService: ParticipantsService,
+    private boardsService: BoardsService,
+    private paymentMethodsService: PaymentMethodsService,
+  ) {}
+
+  async getBoardCalendarReport(
+    boardId: string,
+    yearMonth: string,
+    userId: string,
+  ): Promise<BoardCalendarReport> {
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+
+    const board = await this.boardsService.findByIdOrFail(boardId);
+    const boardCurrency = board.baseCurrency ?? DEFAULT_CURRENCY;
+    const { from, toExclusive } = parseYearMonth(yearMonth);
+    const dateFilter = {
+      $gte: parseDateFrom(from),
+      $lt: parseDateFrom(toExclusive),
+    };
+    const boardObjectId = new Types.ObjectId(boardId);
+
+    const [incomes, expenses] = await Promise.all([
+      this.incomeModel
+        .find({ tripId: boardObjectId, incomeDate: dateFilter })
+        .lean(),
+      this.expenseModel
+        .find({ tripId: boardObjectId, expenseDate: dateFilter })
+        .lean(),
+    ]);
+
+    let totalIncomes = 0;
+    let excludedIncomes = 0;
+    for (const income of incomes) {
+      if (income.currency === boardCurrency) {
+        totalIncomes += income.amount;
+      } else {
+        excludedIncomes += 1;
+      }
+    }
+
+    const matchingExpenses = expenses.filter(
+      (expense) => expense.currency === boardCurrency,
+    );
+    let excludedExpenses = 0;
+    for (const expense of expenses) {
+      if (expense.currency !== boardCurrency) {
+        excludedExpenses += 1;
+      }
+    }
+
+    const totalExpenses = matchingExpenses.reduce(
+      (sum, expense) => sum + expense.amount,
+      0,
+    );
+
+    const [byCategory, byPaymentMethod] = await Promise.all([
+      this.buildCategoryBreakdown(boardId, matchingExpenses),
+      this.buildPaymentMethodBreakdown(matchingExpenses),
+    ]);
+
+    return {
+      boardId,
+      yearMonth,
+      currency: boardCurrency,
+      totalIncomes,
+      totalExpenses,
+      remaining: totalIncomes - totalExpenses,
+      byCategory,
+      byPaymentMethod,
+      excludedDueToCurrencyMismatch: {
+        incomes: excludedIncomes,
+        expenses: excludedExpenses,
+      },
+    };
+  }
+
+  async getCreditCycleReport(
+    boardId: string,
+    paymentMethodId: string,
+    cycle: string,
+    userId: string,
+  ): Promise<CreditCycleReport | CreditCycleClosingDayRequired> {
+    await this.participantsService.ensureParticipantAccess(boardId, userId);
+
+    const availableMethods =
+      await this.paymentMethodsService.findAvailableForBoard(boardId, userId);
+    const paymentMethod = availableMethods.find((item) => {
+      const doc = item as PaymentMethod & { _id: Types.ObjectId };
+      return doc._id.toString() === paymentMethodId;
+    });
+
+    if (!paymentMethod) {
+      throw new BadRequestException(
+        'El medio de pago no está disponible para este tablero',
+      );
+    }
+
+    if (paymentMethod.kind !== PaymentMethodKind.CREDIT) {
+      throw new BadRequestException(
+        'Los reportes por ciclo solo aplican a medios de pago de crédito',
+      );
+    }
+
+    if (paymentMethod.closingDay == null) {
+      return {
+        status: 'closing_day_required',
+        boardId,
+        paymentMethodId,
+        paymentMethodName: paymentMethod.name,
+        message:
+          'Configura el día de cierre de esta tarjeta para ver reportes por ciclo de facturación',
+      };
+    }
+
+    const cycleLabel =
+      cycle === 'current'
+        ? getCurrentCycleClosingMonth(paymentMethod.closingDay)
+        : cycle;
+
+    if (cycle !== 'current') {
+      assertValidCycleLabel(cycleLabel);
+    }
+
+    const board = await this.boardsService.findByIdOrFail(boardId);
+    const boardCurrency = board.baseCurrency ?? DEFAULT_CURRENCY;
+    const { from, toExclusive, periodToInclusive } = getCreditCycleRange(
+      cycleLabel,
+      paymentMethod.closingDay,
+    );
+
+    const expenses = await this.expenseModel
+      .find({
+        tripId: new Types.ObjectId(boardId),
+        expenseDate: {
+          $gte: parseDateFrom(from),
+          $lt: parseDateFrom(toExclusive),
+        },
+        $or: [
+          { paymentMethodId: new Types.ObjectId(paymentMethodId) },
+          { cardId: new Types.ObjectId(paymentMethodId) },
+        ],
+      })
+      .lean();
+
+    const matchingExpenses = expenses.filter(
+      (expense) => expense.currency === boardCurrency,
+    );
+
+    const totalExpenses = matchingExpenses.reduce(
+      (sum, expense) => sum + expense.amount,
+      0,
+    );
+
+    const availableCycles = listRecentCycleLabels(paymentMethod.closingDay, 12);
+
+    this.logger.debug(
+      `Credit cycle report board=${boardId} method=${paymentMethodId} cycle=${cycleLabel}`,
+    );
+
+    return {
+      status: 'ok',
+      boardId,
+      paymentMethodId,
+      paymentMethodName: paymentMethod.name,
+      closingDay: paymentMethod.closingDay,
+      cycleLabel,
+      periodFrom: from,
+      periodToInclusive,
+      currency: boardCurrency,
+      totalExpenses,
+      expenseCount: matchingExpenses.length,
+      availableCycles,
+    };
+  }
+
+  async getConsolidatedReport(
+    yearMonth: string,
+    userId: string,
+    boardIds?: string[],
+  ): Promise<ConsolidatedReport> {
+    const userBoards = (await this.boardsService.findAll(
+      userId,
+    )) as unknown as BoardListItem[];
+    const allowedBoardIds = new Set(
+      userBoards.map((board) => getBoardId(board)),
+    );
+
+    let targetBoardIds: string[];
+    if (boardIds && boardIds.length > 0) {
+      const uniqueBoardIds = [...new Set(boardIds)];
+      const invalid = uniqueBoardIds.filter((id) => !allowedBoardIds.has(id));
+      if (invalid.length > 0) {
+        throw new ForbiddenBoardAccessError(invalid);
+      }
+      targetBoardIds = uniqueBoardIds;
+    } else {
+      targetBoardIds = Array.from(allowedBoardIds);
+    }
+
+    const boards: ConsolidatedBoardSummary[] = [];
+    const totalsByCurrency: Record<string, CurrencyTotals> = {};
+
+    for (const boardId of targetBoardIds) {
+      const boardMeta = userBoards.find(
+        (board) => getBoardId(board) === boardId,
+      );
+      if (!boardMeta) {
+        continue;
+      }
+
+      const summary = await this.getBoardCalendarReport(
+        boardId,
+        yearMonth,
+        userId,
+      );
+
+      const boardSummary: ConsolidatedBoardSummary = {
+        boardId,
+        boardName: boardMeta.name,
+        currency: summary.currency,
+        totalIncomes: summary.totalIncomes,
+        totalExpenses: summary.totalExpenses,
+        remaining: summary.remaining,
+      };
+      boards.push(boardSummary);
+
+      const currencyTotals = totalsByCurrency[summary.currency] ?? {
+        totalIncomes: 0,
+        totalExpenses: 0,
+        remaining: 0,
+        boardCount: 0,
+      };
+      currencyTotals.totalIncomes += summary.totalIncomes;
+      currencyTotals.totalExpenses += summary.totalExpenses;
+      currencyTotals.remaining += summary.remaining;
+      currencyTotals.boardCount += 1;
+      totalsByCurrency[summary.currency] = currencyTotals;
+    }
+
+    return {
+      yearMonth,
+      boards,
+      totalsByCurrency,
+    };
+  }
+
+  private async buildCategoryBreakdown(
+    boardId: string,
+    expenses: Expense[],
+  ): Promise<CategoryBreakdownItem[]> {
+    const totals = new Map<string | null, { total: number; count: number }>();
+
+    for (const expense of expenses) {
+      const key = expense.categoryId?.toString() ?? null;
+      const current = totals.get(key) ?? { total: 0, count: 0 };
+      current.total += expense.amount;
+      current.count += 1;
+      totals.set(key, current);
+    }
+
+    const categoryIds = [...totals.keys()].filter(
+      (id): id is string => id !== null,
+    );
+    const categories =
+      categoryIds.length > 0
+        ? await this.categoryModel
+            .find({
+              tripId: new Types.ObjectId(boardId),
+              _id: { $in: categoryIds.map((id) => new Types.ObjectId(id)) },
+            })
+            .lean()
+        : [];
+
+    const categoryNameById = new Map(
+      categories.map((category) => [category._id.toString(), category.name]),
+    );
+
+    const items: CategoryBreakdownItem[] = [];
+    for (const [categoryId, data] of totals.entries()) {
+      items.push({
+        categoryId,
+        categoryName: categoryId
+          ? (categoryNameById.get(categoryId) ?? 'Categoría eliminada')
+          : 'Sin categoría',
+        total: data.total,
+        count: data.count,
+      });
+    }
+
+    return items.sort((a, b) => b.total - a.total);
+  }
+
+  private async buildPaymentMethodBreakdown(
+    expenses: Expense[],
+  ): Promise<PaymentMethodBreakdownItem[]> {
+    const totals = new Map<string | null, { total: number; count: number }>();
+
+    for (const expense of expenses) {
+      const key = resolveExpensePaymentMethodId(expense);
+      const current = totals.get(key) ?? { total: 0, count: 0 };
+      current.total += expense.amount;
+      current.count += 1;
+      totals.set(key, current);
+    }
+
+    const paymentMethodIds = [...totals.keys()].filter(
+      (id): id is string => id !== null,
+    );
+    const paymentMethods =
+      paymentMethodIds.length > 0
+        ? await this.paymentMethodModel
+            .find({
+              _id: {
+                $in: paymentMethodIds.map((id) => new Types.ObjectId(id)),
+              },
+            })
+            .lean()
+        : [];
+
+    const methodById = new Map(
+      paymentMethods.map((method) => [method._id.toString(), method]),
+    );
+
+    const items: PaymentMethodBreakdownItem[] = [];
+    for (const [paymentMethodId, data] of totals.entries()) {
+      const method = paymentMethodId
+        ? methodById.get(paymentMethodId)
+        : undefined;
+      items.push({
+        paymentMethodId,
+        paymentMethodName: method?.name ?? 'Sin medio de pago',
+        kind: method?.kind ?? null,
+        total: data.total,
+        count: data.count,
+      });
+    }
+
+    return items.sort((a, b) => b.total - a.total);
+  }
+}
+
+export class ForbiddenBoardAccessError extends BadRequestException {
+  constructor(boardIds: string[]) {
+    super(`No tienes acceso a los siguientes tableros: ${boardIds.join(', ')}`);
+  }
+}
+
+// Exported for unit tests of cycle assignment on expenses
+export { resolveCycleClosingMonth };


### PR DESCRIPTION
## Summary

- Nuevo módulo `ReportsModule` con endpoints agregados para reportes del tablero.
- `GET /api/reports/board`: totales del mes calendario + desglose por categoría y medio de pago.
- `GET /api/reports/board/credit-cycle`: reporte por ciclo de tarjeta de crédito (`cycle=current` o `YYYY-MM`); responde `closing_day_required` si falta `closingDay` (sin 500).
- `GET /api/reports/consolidated`: vista multi-board opt-in con totales agrupados por moneda.
- Utilidad `credit-cycle` para rangos de ciclo TC (closingDay 1–28) + tests.

Closes #8

## Self-review (Developer)

- Commit: `a516ef3`
- Bugbot: 2 findings (high/medium) resueltos — validación de `paymentMethodId` vía `findAvailableForBoard`; deduplicación de `boardIds` en consolidado.
- Security: 1 finding medium resuelto — mismo fix de autorización del medio de pago en ciclo TC.

## Cómo probarlo

1. `npm run start:dev` con Mongo y un usuario con board + gastos/ingresos en `2026-07`.
2. Login → obtener JWT.
3. **Mes calendario:**
   ```bash
   curl -H "Authorization: Bearer $TOKEN" \
     "http://localhost:3000/api/reports/board?boardId=<BOARD_ID>&yearMonth=2026-07"
   ```
   Verificar `totalExpenses`, `byCategory`, `byPaymentMethod` coherentes con gastos del mes.
4. **Ciclo TC** (tarjeta crédito con `closingDay=14`):
   ```bash
   curl -H "Authorization: Bearer $TOKEN" \
     "http://localhost:3000/api/reports/board/credit-cycle?boardId=<BOARD_ID>&paymentMethodId=<PM_ID>&cycle=2026-08"
   ```
   `periodFrom` = `2026-07-15`, `periodToInclusive` = `2026-08-14`.
5. Sin `closingDay`: mismo endpoint con tarjeta sin cierre → `status: "closing_day_required"`.
6. **Consolidado:**
   ```bash
   curl -H "Authorization: Bearer $TOKEN" \
     "http://localhost:3000/api/reports/consolidated?yearMonth=2026-07"
   ```
   Opcional: `&boardIds=id1,id2` (solo boards del usuario).

## Requiere antes de deploy

Ninguno (sin migraciones ni env vars nuevas).

## Notas para el reviewer

- Totales excluyen gastos/ingresos en moneda distinta a la del board (misma limitación que `incomes/summary` hasta issue FX #9).
- El reporte por ciclo valida que el medio de pago esté en `findAvailableForBoard`, igual que expenses.
- `GET /incomes/summary` sigue disponible; reports extiende con breakdowns sin romper compatibilidad.