### PR TITLE
[Issue #9] FX: snapshot de tipo de cambio al registrar gasto

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Database
+MONGODB_URI=mongodb://localhost:27017/finanzapp
+
+# Auth
+JWT_SECRET=change-me
+JWT_REFRESH_SECRET=change-me-refresh
+JWT_EXPIRES_IN=15m
+JWT_REFRESH_EXPIRES_IN=7d
+
+# Server
+PORT=8080
+NODE_ENV=development
+FRONTEND_URL=http://localhost:5173
+
+# Email (optional)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+SMTP_SECURE=false
+SMTP_FROM=
+APP_NAME=FinanzApp
+
+# Telegram bot (optional)
+TELEGRAM_BOT_TOKEN=
+WEBHOOK_URL=
+
+# LLM parser for Telegram (optional)
+GROQ_API_KEY=
+
+# FX provider (optional — without key, cross-currency expenses require fxRateOverride)
+# Default provider: exchangerate-api.com (https://www.exchangerate-api.com/)
+FX_API_KEY=
+FX_API_BASE_URL=https://v6.exchangerate-api.com/v6
+FX_CACHE_TTL_MS=3600000

--- a/src/board-month-budgets/board-month-budgets.service.ts
+++ b/src/board-month-budgets/board-month-budgets.service.ts
@@ -19,6 +19,7 @@ import { CategoriesService } from '../categories/categories.service';
 import { resolveBoardId } from '../common/utils/resolve-board-id';
 import { parseYearMonth } from '../common/utils/parse-year-month';
 import { DEFAULT_CURRENCY } from '../common/constants/currencies';
+import { getExpenseAmountInBoardCurrency } from '../common/utils/expense-board-currency';
 
 export interface BoardMonthBudgetProgress {
   budgetId: string;
@@ -218,7 +219,11 @@ export class BoardMonthBudgetsService {
 
     const spentByCategory = new Map<string, number>();
     for (const expense of expenses) {
-      if (expense.currency !== boardCurrency) {
+      const amountInBoardCurrency = getExpenseAmountInBoardCurrency(
+        expense,
+        boardCurrency,
+      );
+      if (amountInBoardCurrency == null) {
         continue;
       }
       const key = expense.categoryId?.toString();
@@ -227,7 +232,7 @@ export class BoardMonthBudgetsService {
       }
       spentByCategory.set(
         key,
-        (spentByCategory.get(key) ?? 0) + expense.amount,
+        (spentByCategory.get(key) ?? 0) + amountInBoardCurrency,
       );
     }
 

--- a/src/bot/bot.service.ts
+++ b/src/bot/bot.service.ts
@@ -2185,7 +2185,7 @@ export class BotService {
       const createExpenseDto: CreateExpenseDto = {
         tripId: updatedBotUpdate.currentTripId.toString(),
         amount: expense.amount!,
-        currency: expense.currency || 'USD',
+        ...(expense.currency ? { currency: expense.currency } : {}),
         description: expense.description || 'Gasto sin descripción',
         merchantName: expense.merchantName,
         budgetId: expense.budgetId,

--- a/src/common/utils/expense-board-currency.spec.ts
+++ b/src/common/utils/expense-board-currency.spec.ts
@@ -1,0 +1,28 @@
+import { getExpenseAmountInBoardCurrency } from './expense-board-currency';
+
+describe('getExpenseAmountInBoardCurrency', () => {
+  it('returns amount when currencies match', () => {
+    expect(
+      getExpenseAmountInBoardCurrency({ amount: 100, currency: 'ARS' }, 'ARS'),
+    ).toBe(100);
+  });
+
+  it('converts using FX snapshot when currencies differ', () => {
+    expect(
+      getExpenseAmountInBoardCurrency(
+        {
+          amount: 10,
+          currency: 'USD',
+          fxRateToBoardCurrency: 1200,
+        },
+        'ARS',
+      ),
+    ).toBe(12000);
+  });
+
+  it('returns null for legacy expenses without FX snapshot', () => {
+    expect(
+      getExpenseAmountInBoardCurrency({ amount: 10, currency: 'USD' }, 'ARS'),
+    ).toBeNull();
+  });
+});

--- a/src/common/utils/expense-board-currency.ts
+++ b/src/common/utils/expense-board-currency.ts
@@ -1,0 +1,29 @@
+export interface ExpenseCurrencyFields {
+  amount: number;
+  currency: string;
+  fxRateToBoardCurrency?: number | null;
+}
+
+/**
+ * Returns the expense amount expressed in the board's base currency.
+ * - Same currency: returns the raw amount.
+ * - Different currency with FX snapshot: returns amount * fxRate.
+ * - Different currency without snapshot (legacy): returns null.
+ */
+export function getExpenseAmountInBoardCurrency(
+  expense: ExpenseCurrencyFields,
+  boardCurrency: string,
+): number | null {
+  if (expense.currency === boardCurrency) {
+    return expense.amount;
+  }
+
+  if (
+    expense.fxRateToBoardCurrency != null &&
+    expense.fxRateToBoardCurrency > 0
+  ) {
+    return expense.amount * expense.fxRateToBoardCurrency;
+  }
+
+  return null;
+}

--- a/src/expenses/dto/create-expense.dto.ts
+++ b/src/expenses/dto/create-expense.dto.ts
@@ -46,6 +46,11 @@ export class CreateExpenseDto {
   })
   currency?: string;
 
+  @IsOptional()
+  @IsNumber({}, { message: 'fxRateOverride debe ser un número' })
+  @Min(0.000001, { message: 'fxRateOverride debe ser mayor a 0' })
+  fxRateOverride?: number;
+
   @IsNotEmpty({ message: 'La descripción es obligatoria' })
   @IsString({ message: 'La descripción debe ser texto' })
   @MinLength(3, { message: 'La descripción debe tener al menos 3 caracteres' })

--- a/src/expenses/expense.schema.ts
+++ b/src/expenses/expense.schema.ts
@@ -36,6 +36,13 @@ export class Expense {
   @Prop({ required: true, default: 'USD' })
   currency: string;
 
+  /** 1 unit of expense.currency = fxRateToBoardCurrency in board.baseCurrency */
+  @Prop({ required: false, min: 0 })
+  fxRateToBoardCurrency?: number;
+
+  @Prop({ type: Date, required: false })
+  fxCapturedAt?: Date;
+
   @Prop({ required: true, minlength: 3, maxlength: 500 })
   description: string;
 

--- a/src/expenses/expenses.board-gates.spec.ts
+++ b/src/expenses/expenses.board-gates.spec.ts
@@ -10,6 +10,7 @@ import { BoardsService } from '../trips/trips.service';
 import { BoardType } from '../trips/board.schema';
 import { CategoriesService } from '../categories/categories.service';
 import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+import { FxService } from '../fx/fx.service';
 
 describe('ExpensesService board gates', () => {
   let service: ExpensesService;
@@ -47,6 +48,13 @@ describe('ExpensesService board gates', () => {
     findAvailableForBoard: jest.fn(),
   };
 
+  const fxService = {
+    resolveSnapshot: jest.fn().mockResolvedValue({
+      fxRateToBoardCurrency: 1,
+      fxCapturedAt: new Date(),
+    }),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -62,6 +70,7 @@ describe('ExpensesService board gates', () => {
         { provide: BoardsService, useValue: boardsService },
         { provide: CategoriesService, useValue: categoriesService },
         { provide: PaymentMethodsService, useValue: paymentMethodsService },
+        { provide: FxService, useValue: fxService },
       ],
     }).compile();
 
@@ -115,6 +124,7 @@ describe('ExpensesService board gates', () => {
       boardsService.findByIdOrFail.mockResolvedValue({
         _id: boardId,
         type: BoardType.EVERYDAY,
+        baseCurrency: 'USD',
       });
       participantModel.findOne
         .mockResolvedValueOnce({ _id: participantId })
@@ -161,6 +171,7 @@ describe('ExpensesService board gates', () => {
           { provide: BoardsService, useValue: boardsService },
           { provide: CategoriesService, useValue: categoriesService },
           { provide: PaymentMethodsService, useValue: paymentMethodsService },
+          { provide: FxService, useValue: fxService },
         ],
       }).compile();
 

--- a/src/expenses/expenses.category-payment.spec.ts
+++ b/src/expenses/expenses.category-payment.spec.ts
@@ -10,6 +10,7 @@ import { BoardsService } from '../trips/trips.service';
 import { BoardType } from '../trips/board.schema';
 import { CategoriesService } from '../categories/categories.service';
 import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+import { FxService } from '../fx/fx.service';
 
 describe('ExpensesService category and payment methods', () => {
   let service: ExpensesService;
@@ -52,6 +53,13 @@ describe('ExpensesService category and payment methods', () => {
     findAvailableForBoard: jest.fn(),
   };
 
+  const fxService = {
+    resolveSnapshot: jest.fn().mockResolvedValue({
+      fxRateToBoardCurrency: 1,
+      fxCapturedAt: new Date(),
+    }),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -67,6 +75,7 @@ describe('ExpensesService category and payment methods', () => {
         { provide: BoardsService, useValue: boardsService },
         { provide: CategoriesService, useValue: categoriesService },
         { provide: PaymentMethodsService, useValue: paymentMethodsService },
+        { provide: FxService, useValue: fxService },
       ],
     }).compile();
 

--- a/src/expenses/expenses.fx.spec.ts
+++ b/src/expenses/expenses.fx.spec.ts
@@ -1,0 +1,237 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { BadRequestException } from '@nestjs/common';
+import { Types } from 'mongoose';
+import { ExpensesService } from './expenses.service';
+import { Expense, ExpenseStatus } from './expense.schema';
+import { Budget } from '../budgets/budget.schema';
+import { Participant } from '../participants/schemas/participant.schema';
+import { BoardsService } from '../trips/trips.service';
+import { BoardType } from '../trips/board.schema';
+import { CategoriesService } from '../categories/categories.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+import { FxService } from '../fx/fx.service';
+
+describe('ExpensesService FX snapshot', () => {
+  let service: ExpensesService;
+
+  const boardId = new Types.ObjectId();
+  const expenseId = new Types.ObjectId();
+  const participantId = new Types.ObjectId();
+  const userId = new Types.ObjectId().toString();
+
+  const expenseModel = {
+    findById: jest.fn(),
+  };
+
+  const budgetModel = {
+    findById: jest.fn(),
+  };
+
+  const participantModel = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const boardsService = {
+    findByIdOrFail: jest.fn(),
+  };
+
+  const categoriesService = {
+    findOne: jest.fn(),
+  };
+
+  const paymentMethodsService = {
+    findAvailableForBoard: jest.fn(),
+  };
+
+  const fxService = {
+    resolveSnapshot: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExpensesService,
+        { provide: getModelToken(Expense.name), useValue: expenseModel },
+        { provide: getModelToken(Budget.name), useValue: budgetModel },
+        {
+          provide: getModelToken(Participant.name),
+          useValue: participantModel,
+        },
+        { provide: BoardsService, useValue: boardsService },
+        { provide: CategoriesService, useValue: categoriesService },
+        { provide: PaymentMethodsService, useValue: paymentMethodsService },
+        { provide: FxService, useValue: fxService },
+      ],
+    }).compile();
+
+    service = module.get(ExpensesService);
+  });
+
+  function mockSuccessfulCreate(savedOverrides: Record<string, unknown> = {}) {
+    boardsService.findByIdOrFail.mockResolvedValue({
+      _id: boardId,
+      type: BoardType.EVERYDAY,
+      baseCurrency: 'ARS',
+    });
+    participantModel.findOne
+      .mockResolvedValueOnce({ _id: participantId })
+      .mockResolvedValueOnce({ _id: participantId });
+    participantModel.find.mockResolvedValue([{ _id: participantId }]);
+
+    const capturedAt = new Date('2026-07-01T12:00:00.000Z');
+    const saved = {
+      _id: expenseId,
+      description: 'Compra USD',
+      amount: 10,
+      currency: 'USD',
+      fxRateToBoardCurrency: 1200,
+      fxCapturedAt: capturedAt,
+      ...savedOverrides,
+    };
+
+    const expenseInstance = {
+      save: jest.fn().mockResolvedValue(saved),
+    };
+    const ExpenseModelCtor = jest
+      .fn()
+      .mockImplementation(() => expenseInstance);
+    Object.assign(ExpenseModelCtor, expenseModel);
+    expenseModel.findById.mockReturnValue({
+      populate: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue({
+        ...saved,
+        tripId: boardId,
+        paidByParticipantId: participantId,
+        createdBy: new Types.ObjectId(userId),
+        isDivisible: false,
+        status: ExpenseStatus.PAID,
+        expenseDate: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    });
+
+    return { ExpenseModelCtor, saved, capturedAt };
+  }
+
+  it('should persist FX snapshot when expense currency differs from board', async () => {
+    const capturedAt = new Date('2026-07-01T12:00:00.000Z');
+    fxService.resolveSnapshot.mockResolvedValue({
+      fxRateToBoardCurrency: 1200,
+      fxCapturedAt: capturedAt,
+    });
+
+    const { ExpenseModelCtor } = mockSuccessfulCreate();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExpensesService,
+        { provide: getModelToken(Expense.name), useValue: ExpenseModelCtor },
+        { provide: getModelToken(Budget.name), useValue: budgetModel },
+        {
+          provide: getModelToken(Participant.name),
+          useValue: participantModel,
+        },
+        { provide: BoardsService, useValue: boardsService },
+        { provide: CategoriesService, useValue: categoriesService },
+        { provide: PaymentMethodsService, useValue: paymentMethodsService },
+        { provide: FxService, useValue: fxService },
+      ],
+    }).compile();
+
+    const expensesService = module.get(ExpensesService);
+    await expensesService.create(
+      {
+        boardId: boardId.toString(),
+        amount: 10,
+        currency: 'USD',
+        description: 'Compra USD',
+      },
+      userId,
+    );
+
+    expect(fxService.resolveSnapshot).toHaveBeenCalledWith(
+      'USD',
+      'ARS',
+      undefined,
+    );
+    expect(ExpenseModelCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currency: 'USD',
+        fxRateToBoardCurrency: 1200,
+        fxCapturedAt: capturedAt,
+      }),
+    );
+  });
+
+  it('should pass fxRateOverride to FX service', async () => {
+    fxService.resolveSnapshot.mockResolvedValue({
+      fxRateToBoardCurrency: 999,
+      fxCapturedAt: new Date(),
+    });
+
+    const { ExpenseModelCtor } = mockSuccessfulCreate({
+      fxRateToBoardCurrency: 999,
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExpensesService,
+        { provide: getModelToken(Expense.name), useValue: ExpenseModelCtor },
+        { provide: getModelToken(Budget.name), useValue: budgetModel },
+        {
+          provide: getModelToken(Participant.name),
+          useValue: participantModel,
+        },
+        { provide: BoardsService, useValue: boardsService },
+        { provide: CategoriesService, useValue: categoriesService },
+        { provide: PaymentMethodsService, useValue: paymentMethodsService },
+        { provide: FxService, useValue: fxService },
+      ],
+    }).compile();
+
+    const expensesService = module.get(ExpensesService);
+    await expensesService.create(
+      {
+        boardId: boardId.toString(),
+        amount: 5,
+        currency: 'USD',
+        fxRateOverride: 999,
+        description: 'Manual FX',
+      },
+      userId,
+    );
+
+    expect(fxService.resolveSnapshot).toHaveBeenCalledWith('USD', 'ARS', 999);
+  });
+
+  it('should reject cross-currency expense when FX cannot be resolved', async () => {
+    boardsService.findByIdOrFail.mockResolvedValue({
+      _id: boardId,
+      type: BoardType.EVERYDAY,
+      baseCurrency: 'ARS',
+    });
+    participantModel.findOne.mockResolvedValue({ _id: participantId });
+    fxService.resolveSnapshot.mockRejectedValue(
+      new BadRequestException(
+        'Tipo de cambio requerido: configura FX_API_KEY o envía fxRateOverride al crear el gasto',
+      ),
+    );
+
+    await expect(
+      service.create(
+        {
+          boardId: boardId.toString(),
+          amount: 10,
+          currency: 'USD',
+          description: 'Sin FX',
+        },
+        userId,
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/src/expenses/expenses.module.ts
+++ b/src/expenses/expenses.module.ts
@@ -14,6 +14,7 @@ import { BoardsModule } from '../trips/trips.module';
 
 import { CategoriesModule } from '../categories/categories.module';
 import { PaymentMethodsModule } from '../payment-methods/payment-methods.module';
+import { FxModule } from '../fx/fx.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { PaymentMethodsModule } from '../payment-methods/payment-methods.module'
     forwardRef(() => BoardsModule),
     forwardRef(() => CategoriesModule),
     forwardRef(() => PaymentMethodsModule),
+    FxModule,
   ],
   controllers: [ExpensesController],
   providers: [ExpensesService],

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -34,6 +34,8 @@ import {
   PaymentMethod as PaymentMethodEntity,
   PaymentMethodKind,
 } from '../payment-methods/payment-method.schema';
+import { FxService } from '../fx/fx.service';
+import { getExpenseAmountInBoardCurrency } from '../common/utils/expense-board-currency';
 
 export interface ExpenseListFilters {
   budgetId?: string;
@@ -104,6 +106,8 @@ interface PopulatedExpense {
   budgetId?: PopulatedBudget | Types.ObjectId;
   amount: number;
   currency: string;
+  fxRateToBoardCurrency?: number;
+  fxCapturedAt?: Date;
   description: string;
   merchantName?: string;
   tags?: string[];
@@ -258,6 +262,7 @@ export class ExpensesService implements OnModuleInit {
     private boardsService: BoardsService,
     private categoriesService: CategoriesService,
     private paymentMethodsService: PaymentMethodsService,
+    private fxService: FxService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -480,13 +485,25 @@ export class ExpensesService implements OnModuleInit {
       legacyPaymentMethod = this.mapKindToLegacyPaymentMethod(method.kind);
     }
 
+    const boardCurrency = board.baseCurrency ?? DEFAULT_CURRENCY;
+    const expenseCurrency =
+      createExpenseDto.currency ?? boardCurrency ?? DEFAULT_CURRENCY;
+
+    const fxSnapshot = await this.fxService.resolveSnapshot(
+      expenseCurrency,
+      boardCurrency,
+      createExpenseDto.fxRateOverride,
+    );
+
     const expense = new this.expenseModel({
       tripId: new Types.ObjectId(boardId),
       budgetId: createExpenseDto.budgetId
         ? new Types.ObjectId(createExpenseDto.budgetId)
         : undefined,
       amount: createExpenseDto.amount,
-      currency: createExpenseDto.currency || DEFAULT_CURRENCY,
+      currency: expenseCurrency,
+      fxRateToBoardCurrency: fxSnapshot.fxRateToBoardCurrency,
+      fxCapturedAt: fxSnapshot.fxCapturedAt,
       description: createExpenseDto.description,
       merchantName: createExpenseDto.merchantName,
       tags: createExpenseDto.tags,
@@ -509,10 +526,11 @@ export class ExpensesService implements OnModuleInit {
     const savedExpense = await expense.save();
 
     if (createExpenseDto.budgetId) {
-      await this.updateBudgetSpent(
-        createExpenseDto.budgetId,
-        savedExpense.amount,
+      const amountForBudget = this.getBudgetAmountForExpense(
+        savedExpense,
+        boardCurrency,
       );
+      await this.updateBudgetSpent(createExpenseDto.budgetId, amountForBudget);
     }
 
     this.logger.log(
@@ -678,7 +696,11 @@ export class ExpensesService implements OnModuleInit {
       );
     }
 
-    const oldAmount = expense.amount;
+    const boardCurrency = board.baseCurrency ?? DEFAULT_CURRENCY;
+    const oldAmountForBudget = this.getBudgetAmountForExpense(
+      expense,
+      boardCurrency,
+    );
 
     if (updateExpenseDto.budgetId) {
       const budget = await this.budgetModel.findById(updateExpenseDto.budgetId);
@@ -901,13 +923,20 @@ export class ExpensesService implements OnModuleInit {
       updateExpenseDto.budgetId !== undefined
     ) {
       if (expense.budgetId) {
-        await this.updateBudgetSpent(expense.budgetId.toString(), -oldAmount);
+        await this.updateBudgetSpent(
+          expense.budgetId.toString(),
+          -oldAmountForBudget,
+        );
       }
 
       if (updatedExpense.budgetId) {
+        const newAmountForBudget = this.getBudgetAmountForExpense(
+          updatedExpense,
+          boardCurrency,
+        );
         await this.updateBudgetSpent(
           updatedExpense.budgetId.toString(),
-          updatedExpense.amount,
+          newAmountForBudget,
         );
       }
     }
@@ -948,13 +977,20 @@ export class ExpensesService implements OnModuleInit {
       );
     }
 
-    const amount = expense.amount;
+    const board = await this.boardsService.findByIdOrFail(
+      expense.tripId.toString(),
+    );
+    const boardCurrency = board.baseCurrency ?? DEFAULT_CURRENCY;
+    const amountForBudget = this.getBudgetAmountForExpense(
+      expense,
+      boardCurrency,
+    );
 
     await this.expenseModel.findByIdAndDelete(id);
 
     if (expense.budgetId) {
       const budgetId = expense.budgetId.toString();
-      await this.updateBudgetSpent(budgetId, -amount);
+      await this.updateBudgetSpent(budgetId, -amountForBudget);
     }
 
     this.logger.log(`Gasto eliminado: ${id}`);
@@ -1740,6 +1776,15 @@ export class ExpensesService implements OnModuleInit {
 
   private transformExpenses(expenses: any[]): Expense[] {
     return expenses.map((expense) => this.transformExpense(expense));
+  }
+
+  private getBudgetAmountForExpense(
+    expense: Pick<Expense, 'amount' | 'currency' | 'fxRateToBoardCurrency'>,
+    boardCurrency: string,
+  ): number {
+    return (
+      getExpenseAmountInBoardCurrency(expense, boardCurrency) ?? expense.amount
+    );
   }
 
   private async updateBudgetSpent(

--- a/src/fx/fx.module.ts
+++ b/src/fx/fx.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { FxService } from './fx.service';
+
+@Module({
+  providers: [FxService],
+  exports: [FxService],
+})
+export class FxModule {}

--- a/src/fx/fx.service.spec.ts
+++ b/src/fx/fx.service.spec.ts
@@ -1,0 +1,93 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { BadRequestException } from '@nestjs/common';
+import { FxService } from './fx.service';
+
+describe('FxService', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  async function createService(apiKey?: string): Promise<FxService> {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FxService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'FX_API_KEY') {
+                return apiKey;
+              }
+              return undefined;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    return module.get(FxService);
+  }
+
+  it('returns rate 1 when currencies match', async () => {
+    const service = await createService('test-key');
+    const snapshot = await service.resolveSnapshot('ARS', 'ARS');
+
+    expect(snapshot.fxRateToBoardCurrency).toBe(1);
+    expect(snapshot.fxCapturedAt).toBeInstanceOf(Date);
+  });
+
+  it('uses manual override without API key', async () => {
+    const service = await createService();
+    const snapshot = await service.resolveSnapshot('USD', 'ARS', 1200);
+
+    expect(snapshot.fxRateToBoardCurrency).toBe(1200);
+  });
+
+  it('requires manual override when API key is missing', async () => {
+    const service = await createService();
+
+    await expect(service.resolveSnapshot('USD', 'ARS')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('fetches rate from provider when API key is configured', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          result: 'success',
+          conversion_rate: 1150.5,
+        }),
+    }) as unknown as typeof fetch;
+
+    const service = await createService('test-key');
+    const snapshot = await service.resolveSnapshot('USD', 'ARS');
+
+    expect(snapshot.fxRateToBoardCurrency).toBe(1150.5);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://v6.exchangerate-api.com/v6/test-key/pair/USD/ARS',
+    );
+  });
+
+  it('reuses cached rate for repeated currency pairs', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          result: 'success',
+          conversion_rate: 1100,
+        }),
+    }) as unknown as typeof fetch;
+
+    const service = await createService('test-key');
+    await service.resolveSnapshot('USD', 'ARS');
+    await service.resolveSnapshot('USD', 'ARS');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/fx/fx.service.ts
+++ b/src/fx/fx.service.ts
@@ -1,0 +1,151 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface FxSnapshot {
+  fxRateToBoardCurrency: number;
+  fxCapturedAt: Date;
+}
+
+interface CachedFxRate {
+  rate: number;
+  expiresAt: number;
+}
+
+interface ExchangeRateApiPairResponse {
+  result?: string;
+  conversion_rate?: number;
+  'error-type'?: string;
+}
+
+@Injectable()
+export class FxService {
+  private readonly logger = new Logger(FxService.name);
+  private readonly enabled: boolean;
+  private readonly apiKey: string | undefined;
+  private readonly apiBaseUrl: string;
+  private readonly rateCache = new Map<string, CachedFxRate>();
+  private readonly cacheTtlMs: number;
+
+  constructor(private readonly configService: ConfigService) {
+    this.apiKey = this.configService.get<string>('FX_API_KEY');
+    this.enabled = !!this.apiKey;
+    this.apiBaseUrl =
+      this.configService.get<string>('FX_API_BASE_URL') ??
+      'https://v6.exchangerate-api.com/v6';
+    this.cacheTtlMs =
+      Number(this.configService.get<string>('FX_CACHE_TTL_MS')) ||
+      60 * 60 * 1000;
+
+    if (!this.enabled) {
+      this.logger.warn(
+        'FX_API_KEY no configurada: gastos en moneda distinta al tablero requieren fxRateOverride',
+      );
+    }
+  }
+
+  isProviderEnabled(): boolean {
+    return this.enabled;
+  }
+
+  async resolveSnapshot(
+    fromCurrency: string,
+    toCurrency: string,
+    manualRate?: number,
+  ): Promise<FxSnapshot> {
+    if (fromCurrency === toCurrency) {
+      return {
+        fxRateToBoardCurrency: 1,
+        fxCapturedAt: new Date(),
+      };
+    }
+
+    if (manualRate !== undefined) {
+      if (manualRate <= 0) {
+        throw new BadRequestException(
+          'fxRateOverride debe ser un número mayor a 0',
+        );
+      }
+      return {
+        fxRateToBoardCurrency: manualRate,
+        fxCapturedAt: new Date(),
+      };
+    }
+
+    if (!this.enabled) {
+      throw new BadRequestException(
+        'Tipo de cambio requerido: configura FX_API_KEY o envía fxRateOverride al crear el gasto',
+      );
+    }
+
+    const rate = await this.fetchRate(fromCurrency, toCurrency);
+    return {
+      fxRateToBoardCurrency: rate,
+      fxCapturedAt: new Date(),
+    };
+  }
+
+  private async fetchRate(
+    fromCurrency: string,
+    toCurrency: string,
+  ): Promise<number> {
+    const cacheKey = `${fromCurrency}:${toCurrency}`;
+    const cached = this.rateCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.rate;
+    }
+
+    const url = `${this.apiBaseUrl}/${this.apiKey}/pair/${fromCurrency}/${toCurrency}`;
+
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch (error) {
+      this.logger.error(
+        `FX provider request failed for ${fromCurrency}->${toCurrency}`,
+        error,
+      );
+      throw new ServiceUnavailableException(
+        'No se pudo contactar al proveedor de tipos de cambio',
+      );
+    }
+
+    if (!response.ok) {
+      throw new ServiceUnavailableException(
+        'El proveedor de tipos de cambio no respondió correctamente',
+      );
+    }
+
+    const data = (await response.json()) as ExchangeRateApiPairResponse;
+
+    if (data.result !== 'success' || data.conversion_rate == null) {
+      this.logger.warn(
+        `FX provider error for ${fromCurrency}->${toCurrency}: ${data['error-type'] ?? 'unknown'}`,
+      );
+      throw new BadRequestException(
+        'No se pudo obtener el tipo de cambio para las monedas indicadas',
+      );
+    }
+
+    if (
+      typeof data.conversion_rate !== 'number' ||
+      !Number.isFinite(data.conversion_rate) ||
+      data.conversion_rate <= 0
+    ) {
+      throw new BadRequestException(
+        'El proveedor de tipos de cambio devolvió una tasa inválida',
+      );
+    }
+
+    this.rateCache.set(cacheKey, {
+      rate: data.conversion_rate,
+      expiresAt: Date.now() + this.cacheTtlMs,
+    });
+
+    return data.conversion_rate;
+  }
+}

--- a/src/incomes/incomes.service.ts
+++ b/src/incomes/incomes.service.ts
@@ -15,6 +15,7 @@ import { BoardsService } from '../trips/trips.service';
 import { resolveBoardId } from '../common/utils/resolve-board-id';
 import { parseYearMonth } from '../common/utils/parse-year-month';
 import { DEFAULT_CURRENCY } from '../common/constants/currencies';
+import { getExpenseAmountInBoardCurrency } from '../common/utils/expense-board-currency';
 
 export interface MonthlyBoardSummary {
   boardId: string;
@@ -24,8 +25,8 @@ export interface MonthlyBoardSummary {
   totalExpenses: number;
   remaining: number;
   /**
-   * Until FX snapshot (issue #9), only amounts in the board currency are
-   * included in totals. Other-currency rows are counted here.
+   * Incomes in other currencies are still excluded until income FX is added.
+   * Expenses use FX snapshot when available (issue #9).
    */
   excludedDueToCurrencyMismatch: {
     incomes: number;
@@ -214,11 +215,15 @@ export class IncomesService {
     let totalExpenses = 0;
     let excludedExpenses = 0;
     for (const expense of expenses) {
-      if (expense.currency === boardCurrency) {
-        totalExpenses += expense.amount;
-      } else {
+      const amountInBoardCurrency = getExpenseAmountInBoardCurrency(
+        expense,
+        boardCurrency,
+      );
+      if (amountInBoardCurrency == null) {
         excludedExpenses += 1;
+        continue;
       }
+      totalExpenses += amountInBoardCurrency;
     }
 
     return {

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -131,6 +131,55 @@ describe('ReportsService', () => {
       });
     });
 
+    it('should include cross-currency expenses with FX snapshot in totals', async () => {
+      incomeModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      expenseModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            amount: 200,
+            currency: 'ARS',
+            categoryId,
+            paymentMethodId,
+          },
+          {
+            amount: 10,
+            currency: 'USD',
+            fxRateToBoardCurrency: 100,
+            categoryId,
+            paymentMethodId,
+          },
+        ]),
+      });
+
+      categoryModel.find.mockReturnValue({
+        lean: jest
+          .fn()
+          .mockResolvedValue([{ _id: categoryId, name: 'Comida' }]),
+      });
+
+      paymentMethodModel.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            _id: paymentMethodId,
+            name: 'Visa',
+            kind: PaymentMethodKind.CREDIT,
+          },
+        ]),
+      });
+
+      const report = await service.getBoardCalendarReport(
+        boardId.toString(),
+        '2026-07',
+        userId,
+      );
+
+      expect(report.totalExpenses).toBe(1200);
+      expect(report.excludedDueToCurrencyMismatch.expenses).toBe(0);
+    });
+
     it('should require participant access', async () => {
       participantsService.ensureParticipantAccess.mockRejectedValue(
         new ForbiddenException('No tienes acceso'),

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -22,6 +22,7 @@ import {
   resolveCycleClosingMonth,
 } from '../common/utils/credit-cycle';
 import { DEFAULT_CURRENCY } from '../common/constants/currencies';
+import { getExpenseAmountInBoardCurrency } from '../common/utils/expense-board-currency';
 
 export interface CategoryBreakdownItem {
   categoryId: string | null;
@@ -168,24 +169,26 @@ export class ReportsService {
       }
     }
 
-    const matchingExpenses = expenses.filter(
-      (expense) => expense.currency === boardCurrency,
-    );
+    let totalExpenses = 0;
     let excludedExpenses = 0;
+    const convertibleExpenses: Expense[] = [];
+
     for (const expense of expenses) {
-      if (expense.currency !== boardCurrency) {
+      const amountInBoardCurrency = getExpenseAmountInBoardCurrency(
+        expense,
+        boardCurrency,
+      );
+      if (amountInBoardCurrency == null) {
         excludedExpenses += 1;
+        continue;
       }
+      totalExpenses += amountInBoardCurrency;
+      convertibleExpenses.push(expense);
     }
 
-    const totalExpenses = matchingExpenses.reduce(
-      (sum, expense) => sum + expense.amount,
-      0,
-    );
-
     const [byCategory, byPaymentMethod] = await Promise.all([
-      this.buildCategoryBreakdown(boardId, matchingExpenses),
-      this.buildPaymentMethodBreakdown(matchingExpenses),
+      this.buildCategoryBreakdown(boardId, convertibleExpenses, boardCurrency),
+      this.buildPaymentMethodBreakdown(convertibleExpenses, boardCurrency),
     ]);
 
     return {
@@ -272,14 +275,20 @@ export class ReportsService {
       })
       .lean();
 
-    const matchingExpenses = expenses.filter(
-      (expense) => expense.currency === boardCurrency,
-    );
+    let totalExpenses = 0;
+    let expenseCount = 0;
 
-    const totalExpenses = matchingExpenses.reduce(
-      (sum, expense) => sum + expense.amount,
-      0,
-    );
+    for (const expense of expenses) {
+      const amountInBoardCurrency = getExpenseAmountInBoardCurrency(
+        expense,
+        boardCurrency,
+      );
+      if (amountInBoardCurrency == null) {
+        continue;
+      }
+      totalExpenses += amountInBoardCurrency;
+      expenseCount += 1;
+    }
 
     const availableCycles = listRecentCycleLabels(paymentMethod.closingDay, 12);
 
@@ -298,7 +307,7 @@ export class ReportsService {
       periodToInclusive,
       currency: boardCurrency,
       totalExpenses,
-      expenseCount: matchingExpenses.length,
+      expenseCount,
       availableCycles,
     };
   }
@@ -377,13 +386,21 @@ export class ReportsService {
   private async buildCategoryBreakdown(
     boardId: string,
     expenses: Expense[],
+    boardCurrency: string,
   ): Promise<CategoryBreakdownItem[]> {
     const totals = new Map<string | null, { total: number; count: number }>();
 
     for (const expense of expenses) {
+      const amountInBoardCurrency = getExpenseAmountInBoardCurrency(
+        expense,
+        boardCurrency,
+      );
+      if (amountInBoardCurrency == null) {
+        continue;
+      }
       const key = expense.categoryId?.toString() ?? null;
       const current = totals.get(key) ?? { total: 0, count: 0 };
-      current.total += expense.amount;
+      current.total += amountInBoardCurrency;
       current.count += 1;
       totals.set(key, current);
     }
@@ -422,13 +439,21 @@ export class ReportsService {
 
   private async buildPaymentMethodBreakdown(
     expenses: Expense[],
+    boardCurrency: string,
   ): Promise<PaymentMethodBreakdownItem[]> {
     const totals = new Map<string | null, { total: number; count: number }>();
 
     for (const expense of expenses) {
+      const amountInBoardCurrency = getExpenseAmountInBoardCurrency(
+        expense,
+        boardCurrency,
+      );
+      if (amountInBoardCurrency == null) {
+        continue;
+      }
       const key = resolveExpensePaymentMethodId(expense);
       const current = totals.get(key) ?? { total: 0, count: 0 };
-      current.total += expense.amount;
+      current.total += amountInBoardCurrency;
       current.count += 1;
       totals.set(key, current);
     }


### PR DESCRIPTION
## Summary

- Nuevo `FxService` con proveedor configurable (`FX_API_KEY` / exchangerate-api.com), override manual (`fxRateOverride`) y caché en memoria por par de monedas.
- Los gastos en moneda distinta al tablero persisten `fxRateToBoardCurrency` y `fxCapturedAt` al crearse.
- Reportes, summary mensual y presupuestos por categoría suman montos convertidos a la moneda del board.
- Añadido `.env.example` documentando variables FX.

Closes #9

## Self-review (Developer)

- Commit: `12329b7353cff5f9fea7e4f739cd5da4d76f8db9`
- Bugbot: 2 high + 1 medium corregidos (budget update/remove con FX, bot sin forzar USD, validación de tasa del proveedor + caché FX)
- Security: 1 medium mitigado (caché TTL en `FxService`); `fxRateOverride` documentado como diseño intencional para modo manual

## Cómo probarlo

1. Copiar `.env.example` a `.env` y levantar el backend (`npm run start:dev`).
2. Crear un tablero everyday con `baseCurrency: ARS`.
3. **Sin `FX_API_KEY`:** crear gasto USD con override:
   ```bash
   curl -X POST http://localhost:8080/api/expenses \
     -H "Authorization: Bearer <token>" \
     -H "Content-Type: application/json" \
     -d '{"boardId":"<id>","amount":10,"currency":"USD","fxRateOverride":1200,"description":"Compra USD"}'
   ```
   Verificar respuesta con `fxRateToBoardCurrency: 1200` y `fxCapturedAt`.
4. Consultar summary mensual (`GET /api/incomes/summary?boardId=<id>&yearMonth=2026-08`) — `totalExpenses` debe incluir 12000 ARS (10 × 1200).
5. Consultar reporte calendario (`GET /api/reports/board/<id>/calendar?yearMonth=2026-08`) — mismo total en ARS, `excludedDueToCurrencyMismatch.expenses: 0`.
6. **Con `FX_API_KEY`:** repetir paso 3 sin `fxRateOverride`; debe obtener tasa del proveedor automáticamente.
7. Intentar gasto USD sin API key ni override — debe responder 400 con mensaje claro.

## Requiere antes de deploy

- Opcional: `FX_API_KEY` para tasas automáticas (sin ella, cross-currency requiere `fxRateOverride`).
- Opcional: `FX_API_BASE_URL`, `FX_CACHE_TTL_MS` (default 1h).
- Sin migraciones: campos nuevos son opcionales en documentos existentes.

## Notas para el reviewer

- Gastos legacy en moneda distinta sin snapshot siguen excluidos de totales (comportamiento previo).
- Ingresos en otra moneda aún se excluyen del summary (FX de incomes fuera de alcance).
- El bot Telegram ya no fuerza `USD` cuando el usuario no indicó moneda; usa la del tablero vía default en `ExpensesService.create`.