### PR TITLE
[Issue #10] Telegram: rewrite para boards (activeBoard + everyday + travel)

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -19,6 +19,7 @@ import { LoginDto } from './dto/login.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { UpdateUserPreferencesDto } from '../users/dto/update-user-preferences.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { Public } from './decorators/public.decorator';
 import { GetUser } from './decorators/get-user.decorator';
@@ -188,5 +189,18 @@ export class AuthController {
       updateProfileDto,
     );
     return updatedUser;
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('preferences')
+  @HttpCode(HttpStatus.OK)
+  async updatePreferences(
+    @GetUser() user: UserDocument,
+    @Body() updatePreferencesDto: UpdateUserPreferencesDto,
+  ) {
+    return this.authService.updatePreferences(
+      user._id.toString(),
+      updatePreferencesDto,
+    );
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { User, UserSchema } from '../users/user.schema';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { APP_GUARD } from '@nestjs/core';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
     }),
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
     NotificationsModule,
+    UsersModule,
   ],
   controllers: [AuthController],
   providers: [

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -14,6 +14,8 @@ import { User, UserDocument } from '../users/user.schema';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { UpdateUserPreferencesDto } from '../users/dto/update-user-preferences.dto';
+import { UserPreferencesService } from '../users/user-preferences.service';
 import {
   JwtPayload,
   JwtSignPayload,
@@ -30,6 +32,7 @@ export class AuthService {
     private jwtService: JwtService,
     private configService: ConfigService,
     private notificationsService: NotificationsService,
+    private userPreferencesService: UserPreferencesService,
   ) {}
 
   private async generateUsernameForUser(user: UserDocument): Promise<string> {
@@ -459,6 +462,7 @@ export class AuthService {
     lastName: string;
     emailVerified: boolean;
     lastLogin?: Date;
+    activeBoardId: string | null;
   }> {
     const user = await this.userModel.findById(userId).exec();
 
@@ -479,7 +483,18 @@ export class AuthService {
       lastName: user.lastName,
       emailVerified: user.emailVerified,
       lastLogin: user.lastLogin,
+      activeBoardId: user.activeBoardId?.toString() ?? null,
     };
+  }
+
+  async updatePreferences(
+    userId: string,
+    dto: UpdateUserPreferencesDto,
+  ): Promise<{ activeBoardId: string | null }> {
+    return this.userPreferencesService.updatePreferences(
+      userId,
+      dto.activeBoardId,
+    );
   }
 
   private sanitizeUser(user: UserDocument) {

--- a/src/bot/bot-update.schema.ts
+++ b/src/bot/bot-update.schema.ts
@@ -6,6 +6,8 @@ export enum ConversationState {
   PARSING_EXPENSE = 'parsing_expense',
   ASKING_TRIP = 'asking_trip',
   ASKING_BUCKET = 'asking_bucket',
+  ASKING_CATEGORY = 'asking_category',
+  ASKING_EVERYDAY_PAYMENT = 'asking_everyday_payment',
   ASKING_PAYER = 'asking_payer',
   ASKING_MERCHANT = 'asking_merchant',
   ASKING_SPLIT = 'asking_split',
@@ -42,9 +44,11 @@ export class BotUpdate {
     description?: string;
     merchantName?: string;
     budgetId?: string;
+    categoryId?: string;
     paidByParticipantId?: string;
     paymentMethod?: string;
     cardId?: string;
+    paymentMethodId?: string;
     isDivisible?: boolean;
     splitType?: string;
     splits?: Array<{ participantId: string; amount?: number }>;

--- a/src/bot/bot.module.ts
+++ b/src/bot/bot.module.ts
@@ -16,9 +16,14 @@ import { TripsModule } from '../trips/trips.module';
 import { ParticipantsModule } from '../participants/participants.module';
 import { BudgetsModule } from '../budgets/budgets.module';
 import { CardsModule } from '../cards/cards.module';
+import { CategoriesModule } from '../categories/categories.module';
+import { PaymentMethodsModule } from '../payment-methods/payment-methods.module';
+import { UsersModule } from '../users/users.module';
 import { TelegramClientService } from './telegram/telegram-client.service';
 import { UserLinkingService } from './linking/user-linking.service';
 import { BotUpdateRepository } from './repositories/bot-update.repository';
+import { BoardCommandHandler } from './handlers/board-command.handler';
+import { EverydayExpenseHandler } from './handlers/everyday-expense.handler';
 
 @Module({
   imports: [
@@ -32,6 +37,9 @@ import { BotUpdateRepository } from './repositories/bot-update.repository';
     forwardRef(() => ParticipantsModule),
     forwardRef(() => BudgetsModule),
     forwardRef(() => CardsModule),
+    forwardRef(() => CategoriesModule),
+    forwardRef(() => PaymentMethodsModule),
+    UsersModule,
   ],
   controllers: [BotController],
   providers: [
@@ -42,6 +50,8 @@ import { BotUpdateRepository } from './repositories/bot-update.repository';
     TelegramClientService,
     UserLinkingService,
     BotUpdateRepository,
+    BoardCommandHandler,
+    EverydayExpenseHandler,
   ],
   exports: [BotService],
 })

--- a/src/bot/bot.service.ts
+++ b/src/bot/bot.service.ts
@@ -26,7 +26,11 @@ import { PopulatedParticipant, PopulatedBudget } from './types/populated.types';
 import { TelegramClientService } from './telegram/telegram-client.service';
 import { UserLinkingService } from './linking/user-linking.service';
 import { BotUpdateRepository } from './repositories/bot-update.repository';
-import { getCardId } from './utils/bot-helpers';
+import { getCardId, getDocumentId } from './utils/bot-helpers';
+import { UserPreferencesService } from '../users/user-preferences.service';
+import { BoardType } from '../trips/board.schema';
+import { BoardCommandHandler } from './handlers/board-command.handler';
+import { EverydayExpenseHandler } from './handlers/everyday-expense.handler';
 
 @Injectable()
 export class BotService {
@@ -46,6 +50,9 @@ export class BotService {
     private telegramClient: TelegramClientService,
     private userLinkingService: UserLinkingService,
     private botUpdateRepository: BotUpdateRepository,
+    private userPreferencesService: UserPreferencesService,
+    private boardCommandHandler: BoardCommandHandler,
+    private everydayExpenseHandler: EverydayExpenseHandler,
   ) {}
 
   async handleUpdate(update: TelegramUpdate): Promise<void> {
@@ -114,6 +121,22 @@ export class BotService {
       return;
     }
 
+    if (text.startsWith('/board')) {
+      const botUpdate =
+        await this.botUpdateRepository.getOrCreateBotUpdate(telegramUserId);
+
+      if (!botUpdate.userId) {
+        await this.telegramClient.sendMessage(
+          telegramUserId,
+          '⚠️ Primero debes vincular tu cuenta. Ve a la web y genera un token de vinculación, luego usa /start <token>',
+        );
+        return;
+      }
+
+      await this.boardCommandHandler.handle(botUpdate, text, telegramUserId);
+      return;
+    }
+
     this.logger.log('Obteniendo botUpdate...');
     const botUpdate =
       await this.botUpdateRepository.getOrCreateBotUpdate(telegramUserId);
@@ -162,6 +185,20 @@ export class BotService {
       case ConversationState.ASKING_TRIP:
         this.logger.log('Estado ASKING_TRIP, llamando handleTripSelection...');
         await this.handleTripSelection(botUpdate, text, telegramUserId);
+        break;
+      case ConversationState.ASKING_CATEGORY:
+        await this.handleEverydayCategorySelection(
+          botUpdate,
+          text,
+          telegramUserId,
+        );
+        break;
+      case ConversationState.ASKING_EVERYDAY_PAYMENT:
+        await this.handleEverydayPaymentSelection(
+          botUpdate,
+          text,
+          telegramUserId,
+        );
         break;
       case ConversationState.ASKING_BUCKET:
         this.logger.log(
@@ -250,12 +287,41 @@ export class BotService {
       return;
     }
 
-    const trips = await this.tripsService.findAll(botUpdate.userId.toString());
+    const userId = botUpdate.userId.toString();
+    const activeBoard =
+      await this.userPreferencesService.resolveActiveBoard(userId);
+
+    if (!activeBoard) {
+      await this.telegramClient.sendMessage(
+        telegramUserId,
+        '⚠️ No tenés un tablero activo.\n\n' +
+          'Usá /board para ver tus tableros y elegir uno.\n' +
+          'Después podés cargar gastos con un mensaje como "Super 15000".',
+      );
+      return;
+    }
+
+    const boardId = getDocumentId(activeBoard);
+    const boardType = activeBoard.type ?? BoardType.TRAVEL;
+    botUpdate.currentTripId = new Types.ObjectId(boardId);
+    await botUpdate.save();
+
+    if (boardType === BoardType.EVERYDAY) {
+      await this.everydayExpenseHandler.startFromMessage(
+        botUpdate,
+        text,
+        telegramUserId,
+        boardId,
+      );
+      return;
+    }
+
+    const trips = await this.tripsService.findAll(userId);
 
     if (trips.length === 0) {
       await this.telegramClient.sendMessage(
         telegramUserId,
-        '⚠️ No tienes viajes activos. Crea uno desde la web primero.',
+        '⚠️ No tienes tableros de viaje. Creá uno desde la web primero.',
       );
       return;
     }
@@ -348,6 +414,16 @@ export class BotService {
       await botUpdate.save();
 
       await this.continueWithTrip(botUpdate, telegramUserId, tripId);
+      return;
+    }
+
+    // Active travel board is set — skip trip picker when it matches
+    const activeOnList = trips.some((t) => {
+      const trip = t as unknown as { _id: Types.ObjectId };
+      return trip._id.toString() === boardId;
+    });
+    if (activeOnList) {
+      await this.continueWithTrip(botUpdate, telegramUserId, boardId);
       return;
     }
 
@@ -1597,6 +1673,38 @@ export class BotService {
     );
   }
 
+  private async handleEverydayCategorySelection(
+    botUpdate: BotUpdateDocument,
+    text: string,
+    telegramUserId: number,
+  ): Promise<void> {
+    if (!botUpdate.currentTripId) {
+      return;
+    }
+    await this.everydayExpenseHandler.handleCategorySelection(
+      botUpdate,
+      text,
+      telegramUserId,
+      botUpdate.currentTripId.toString(),
+    );
+  }
+
+  private async handleEverydayPaymentSelection(
+    botUpdate: BotUpdateDocument,
+    text: string,
+    telegramUserId: number,
+  ): Promise<void> {
+    if (!botUpdate.currentTripId) {
+      return;
+    }
+    await this.everydayExpenseHandler.handlePaymentSelection(
+      botUpdate,
+      text,
+      telegramUserId,
+      botUpdate.currentTripId.toString(),
+    );
+  }
+
   private async handleCallbackQuery(
     callback: TelegramUpdate['callback_query'],
   ): Promise<void> {
@@ -1624,7 +1732,40 @@ export class BotService {
     }
 
     try {
-      if (data.startsWith('trip:')) {
+      if (data.startsWith('board:')) {
+        const boardId = data.replace('board:', '');
+        await this.boardCommandHandler.handleBoardCallback(
+          botUpdate,
+          boardId,
+          telegramUserId,
+        );
+        await this.telegramClient.answerCallbackQuery(callbackQueryId);
+      } else if (data.startsWith('everyday-category:')) {
+        const categoryId = data.replace('everyday-category:', '');
+        await this.everydayExpenseHandler.handleCategoryCallback(
+          botUpdate,
+          categoryId,
+          telegramUserId,
+          botUpdate.currentTripId!.toString(),
+        );
+        await this.telegramClient.answerCallbackQuery(callbackQueryId);
+      } else if (data.startsWith('everyday-payment:')) {
+        const paymentMethodId = data.replace('everyday-payment:', '');
+        await this.everydayExpenseHandler.handlePaymentCallback(
+          botUpdate,
+          paymentMethodId,
+          telegramUserId,
+          botUpdate.currentTripId!.toString(),
+        );
+        await this.telegramClient.answerCallbackQuery(callbackQueryId);
+      } else if (data === 'everyday-confirm:yes') {
+        await this.everydayExpenseHandler.confirmExpense(
+          botUpdate,
+          telegramUserId,
+          botUpdate.currentTripId!.toString(),
+        );
+        await this.telegramClient.answerCallbackQuery(callbackQueryId);
+      } else if (data.startsWith('trip:')) {
         const tripId = data.replace('trip:', '');
         const updatedBotUpdate = await this.botUpdateModel
           .findById(botUpdate._id)

--- a/src/bot/handlers/board-command.handler.ts
+++ b/src/bot/handlers/board-command.handler.ts
@@ -1,0 +1,180 @@
+import { Injectable } from '@nestjs/common';
+import { Types } from 'mongoose';
+import { BoardsService } from '../../trips/trips.service';
+import { BoardType } from '../../trips/board.schema';
+import { UserPreferencesService } from '../../users/user-preferences.service';
+import { BotUpdateDocument, ConversationState } from '../bot-update.schema';
+import { TelegramClientService } from '../telegram/telegram-client.service';
+import { getDocumentId } from '../utils/bot-helpers';
+
+function boardTypeEmoji(type: BoardType): string {
+  return type === BoardType.EVERYDAY ? '🏠' : '✈️';
+}
+
+function boardTypeLabel(type: BoardType): string {
+  return type === BoardType.EVERYDAY ? 'Everyday' : 'Viaje';
+}
+
+@Injectable()
+export class BoardCommandHandler {
+  constructor(
+    private boardsService: BoardsService,
+    private userPreferencesService: UserPreferencesService,
+    private telegramClient: TelegramClientService,
+  ) {}
+
+  async handle(
+    botUpdate: BotUpdateDocument,
+    text: string,
+    telegramUserId: number,
+  ): Promise<void> {
+    const userId = botUpdate.userId!.toString();
+    const boards = (await this.boardsService.findAll(
+      userId,
+    )) as unknown as Array<
+      { name: string; type?: BoardType } & Record<string, unknown>
+    >;
+
+    if (boards.length === 0) {
+      await this.telegramClient.sendMessage(
+        telegramUserId,
+        '⚠️ No tenés tableros todavía. Creá uno desde la web y volvé a intentar.',
+      );
+      return;
+    }
+
+    const parts = text.trim().split(/\s+/);
+    const selection = parts.slice(1).join(' ').trim();
+
+    if (!selection) {
+      await this.listBoards(botUpdate, telegramUserId, boards);
+      return;
+    }
+
+    const activeBoardId =
+      await this.userPreferencesService.getActiveBoardId(userId);
+
+    const matched = this.matchBoard(boards, selection, activeBoardId);
+    if (!matched) {
+      await this.telegramClient.sendMessage(
+        telegramUserId,
+        '⚠️ No encontré ese tablero. Usá /board para ver la lista o tocá un botón.',
+      );
+      return;
+    }
+
+    await this.setActiveBoard(
+      botUpdate,
+      telegramUserId,
+      getDocumentId(matched),
+      matched.name,
+      matched.type ?? BoardType.TRAVEL,
+    );
+  }
+
+  async handleBoardCallback(
+    botUpdate: BotUpdateDocument,
+    boardId: string,
+    telegramUserId: number,
+  ): Promise<void> {
+    const userId = botUpdate.userId!.toString();
+    const board = await this.boardsService.findOne(boardId, userId);
+    await this.setActiveBoard(
+      botUpdate,
+      telegramUserId,
+      boardId,
+      board.name,
+      board.type ?? BoardType.TRAVEL,
+    );
+  }
+
+  private async listBoards(
+    botUpdate: BotUpdateDocument,
+    telegramUserId: number,
+    boards: Array<{ name: string; type?: BoardType } & Record<string, unknown>>,
+  ): Promise<void> {
+    const activeBoardId = await this.userPreferencesService.getActiveBoardId(
+      botUpdate.userId!.toString(),
+    );
+
+    const lines = boards.map((board, index) => {
+      const id = getDocumentId(board);
+      const active = id === activeBoardId ? ' ✅' : '';
+      const type = board.type ?? BoardType.TRAVEL;
+      return `${index + 1}. ${boardTypeEmoji(type)} ${board.name} (${boardTypeLabel(type)})${active}`;
+    });
+
+    const message =
+      '📋 *Tus tableros*\n\n' +
+      lines.join('\n') +
+      '\n\nTocá un tablero para activarlo o escribí:\n`/board <nombre>`';
+
+    const buttons = boards.slice(0, 10).map((board) => {
+      const id = getDocumentId(board);
+      const type = board.type ?? BoardType.TRAVEL;
+      const isActive = id === activeBoardId;
+      return {
+        text: `${isActive ? '✅ ' : ''}${boardTypeEmoji(type)} ${board.name}`,
+        callback_data: `board:${id}`,
+      };
+    });
+
+    await this.telegramClient.sendMessageWithButtons(
+      telegramUserId,
+      message,
+      buttons,
+    );
+  }
+
+  private matchBoard(
+    boards: Array<{ name: string; type?: BoardType } & Record<string, unknown>>,
+    selection: string,
+    activeBoardId: string | null,
+  ):
+    | ({ name: string; type?: BoardType } & Record<string, unknown>)
+    | undefined {
+    const index = Number.parseInt(selection, 10);
+    if (!Number.isNaN(index) && index >= 1 && index <= boards.length) {
+      return boards[index - 1];
+    }
+
+    const normalized = selection.toLowerCase();
+    const byName = boards.find((board) =>
+      board.name.toLowerCase().includes(normalized),
+    );
+    if (byName) {
+      return byName;
+    }
+
+    if (normalized === 'activo' && activeBoardId) {
+      return boards.find((board) => getDocumentId(board) === activeBoardId);
+    }
+
+    return undefined;
+  }
+
+  private async setActiveBoard(
+    botUpdate: BotUpdateDocument,
+    telegramUserId: number,
+    boardId: string,
+    boardName: string,
+    boardType: BoardType,
+  ): Promise<void> {
+    const userId = botUpdate.userId!.toString();
+    await this.userPreferencesService.setActiveBoardId(userId, boardId);
+
+    botUpdate.currentTripId = new Types.ObjectId(boardId);
+    botUpdate.state = ConversationState.IDLE;
+    botUpdate.pendingExpense = undefined;
+    await botUpdate.save();
+
+    const typeLabel = boardTypeLabel(boardType);
+    await this.telegramClient.sendMessage(
+      telegramUserId,
+      `✅ Tablero activo: *${boardName}* (${typeLabel})\n\n` +
+        'Podés cargar gastos enviándome un mensaje.\n' +
+        'Ejemplo everyday: "Super 15000"\n' +
+        'Ejemplo viaje: "Cena 120 usd compartido"',
+    );
+  }
+}

--- a/src/bot/handlers/everyday-expense.handler.ts
+++ b/src/bot/handlers/everyday-expense.handler.ts
@@ -1,0 +1,432 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import {
+  BotUpdate,
+  BotUpdateDocument,
+  ConversationState,
+} from '../bot-update.schema';
+import { MessageParserService } from '../parsers/message-parser.service';
+import { TelegramClientService } from '../telegram/telegram-client.service';
+import { CategoriesService } from '../../categories/categories.service';
+import { PaymentMethodsService } from '../../payment-methods/payment-methods.service';
+import { ExpensesService } from '../../expenses/expenses.service';
+import { CreateExpenseDto } from '../../expenses/dto/create-expense.dto';
+import { ExpenseStatus, PaymentMethod } from '../../expenses/expense.schema';
+import { Category } from '../../categories/category.schema';
+import { PaymentMethod as PaymentMethodEntity } from '../../payment-methods/payment-method.schema';
+import { getDocumentId } from '../utils/bot-helpers';
+
+@Injectable()
+export class EverydayExpenseHandler {
+  private readonly logger = new Logger(EverydayExpenseHandler.name);
+
+  constructor(
+    @InjectModel(BotUpdate.name)
+    private botUpdateModel: Model<BotUpdateDocument>,
+    private messageParser: MessageParserService,
+    private telegramClient: TelegramClientService,
+    private categoriesService: CategoriesService,
+    private paymentMethodsService: PaymentMethodsService,
+    private expensesService: ExpensesService,
+  ) {}
+
+  async startFromMessage(
+    botUpdate: BotUpdateDocument,
+    text: string,
+    telegramUserId: number,
+    boardId: string,
+  ): Promise<void> {
+    const parsed = await this.messageParser.parse(text, {
+      tripName: 'Everyday',
+      participants: [],
+      budgets: [],
+      userName: 'Usuario',
+    });
+
+    if (!parsed.amount) {
+      await this.telegramClient.sendMessage(
+        telegramUserId,
+        '⚠️ No pude detectar el monto. Incluí un número.\nEjemplo: "Super 15000"',
+      );
+      return;
+    }
+
+    botUpdate.pendingExpense = {
+      amount: parsed.amount,
+      currency: parsed.currency,
+      description: this.normalizeDescription(parsed.description, text),
+      isDivisible: false,
+    };
+
+    const categories = await this.categoriesService.findAllByBoard(
+      boardId,
+      botUpdate.userId!.toString(),
+    );
+
+    const matchedCategory = this.matchCategoryByText(categories, text);
+    if (matchedCategory) {
+      botUpdate.pendingExpense.categoryId = getDocumentId(matchedCategory);
+      botUpdate.markModified('pendingExpense');
+    }
+
+    if (botUpdate.pendingExpense.categoryId) {
+      await this.continueToPaymentMethod(
+        botUpdate,
+        telegramUserId,
+        boardId,
+        text,
+      );
+      return;
+    }
+
+    botUpdate.state = ConversationState.ASKING_CATEGORY;
+    await botUpdate.save();
+    await this.askForCategory(botUpdate, telegramUserId, categories);
+  }
+
+  async handleCategorySelection(
+    botUpdate: BotUpdateDocument,
+    text: string,
+    telegramUserId: number,
+    boardId: string,
+  ): Promise<void> {
+    const categories = await this.categoriesService.findAllByBoard(
+      boardId,
+      botUpdate.userId!.toString(),
+    );
+
+    const matched = this.matchCategoryByText(categories, text);
+    if (!matched) {
+      await this.telegramClient.sendMessage(
+        telegramUserId,
+        '⚠️ No encontré esa categoría. Elegí una de los botones o escribí el nombre.',
+      );
+      return;
+    }
+
+    const updated = await this.reloadBotUpdate(botUpdate._id.toString());
+    if (!updated?.pendingExpense) {
+      return;
+    }
+
+    updated.pendingExpense.categoryId = getDocumentId(matched);
+    updated.markModified('pendingExpense');
+    await updated.save();
+
+    await this.continueToPaymentMethod(updated, telegramUserId, boardId, text);
+  }
+
+  async handleCategoryCallback(
+    botUpdate: BotUpdateDocument,
+    categoryId: string,
+    telegramUserId: number,
+    boardId: string,
+  ): Promise<void> {
+    const updated = await this.reloadBotUpdate(botUpdate._id.toString());
+    if (!updated?.pendingExpense) {
+      return;
+    }
+
+    updated.pendingExpense.categoryId = categoryId;
+    updated.markModified('pendingExpense');
+    await updated.save();
+
+    await this.continueToPaymentMethod(updated, telegramUserId, boardId, '');
+  }
+
+  async handlePaymentSelection(
+    botUpdate: BotUpdateDocument,
+    text: string,
+    telegramUserId: number,
+    boardId: string,
+  ): Promise<void> {
+    const methods = await this.paymentMethodsService.findAvailableForBoard(
+      boardId,
+      botUpdate.userId!.toString(),
+    );
+
+    const matched = this.matchPaymentMethodByText(methods, text);
+    if (!matched) {
+      await this.telegramClient.sendMessage(
+        telegramUserId,
+        '⚠️ No encontré ese medio de pago. Elegí uno de los botones.',
+      );
+      return;
+    }
+
+    const updated = await this.reloadBotUpdate(botUpdate._id.toString());
+    if (!updated?.pendingExpense) {
+      return;
+    }
+
+    updated.pendingExpense.paymentMethodId = getDocumentId(matched);
+    updated.markModified('pendingExpense');
+    updated.state = ConversationState.CONFIRMING;
+    await updated.save();
+
+    await this.showConfirmation(updated, telegramUserId, boardId, methods);
+  }
+
+  async handlePaymentCallback(
+    botUpdate: BotUpdateDocument,
+    paymentMethodId: string,
+    telegramUserId: number,
+    boardId: string,
+  ): Promise<void> {
+    const updated = await this.reloadBotUpdate(botUpdate._id.toString());
+    if (!updated?.pendingExpense) {
+      return;
+    }
+
+    updated.pendingExpense.paymentMethodId = paymentMethodId;
+    updated.markModified('pendingExpense');
+    updated.state = ConversationState.CONFIRMING;
+    await updated.save();
+
+    const methods = await this.paymentMethodsService.findAvailableForBoard(
+      boardId,
+      botUpdate.userId!.toString(),
+    );
+    await this.showConfirmation(updated, telegramUserId, boardId, methods);
+  }
+
+  async confirmExpense(
+    botUpdate: BotUpdateDocument,
+    telegramUserId: number,
+    boardId: string,
+  ): Promise<void> {
+    const updated = await this.reloadBotUpdate(botUpdate._id.toString());
+    const expense = updated?.pendingExpense;
+    if (!updated || !expense?.amount || !expense.categoryId) {
+      await this.telegramClient.sendMessage(
+        telegramUserId,
+        '❌ Error: faltan datos del gasto.',
+      );
+      return;
+    }
+
+    try {
+      const createExpenseDto: CreateExpenseDto = {
+        boardId,
+        amount: expense.amount,
+        ...(expense.currency ? { currency: expense.currency } : {}),
+        description: expense.description || 'Gasto sin descripción',
+        categoryId: expense.categoryId,
+        paymentMethodId: expense.paymentMethodId,
+        status: ExpenseStatus.PAID,
+        paymentMethod: expense.paymentMethodId
+          ? PaymentMethod.CARD
+          : PaymentMethod.CASH,
+        isDivisible: false,
+        expenseDate: new Date().toISOString(),
+      };
+
+      await this.expensesService.create(
+        createExpenseDto,
+        updated.userId!.toString(),
+      );
+
+      updated.state = ConversationState.IDLE;
+      updated.pendingExpense = undefined;
+      await updated.save();
+
+      await this.telegramClient.sendMessage(
+        telegramUserId,
+        '✅ ¡Gasto guardado en tu tablero everyday!\n\nPodés verlo en la web.',
+      );
+    } catch (error) {
+      this.logger.error('Error creating everyday expense', error);
+      await this.telegramClient.sendMessage(
+        telegramUserId,
+        '❌ Error al guardar el gasto. Revisá los datos e intentá de nuevo.',
+      );
+    }
+  }
+
+  private async continueToPaymentMethod(
+    botUpdate: BotUpdateDocument,
+    telegramUserId: number,
+    boardId: string,
+    text: string,
+  ): Promise<void> {
+    const methods = await this.paymentMethodsService.findAvailableForBoard(
+      boardId,
+      botUpdate.userId!.toString(),
+    );
+
+    const matched = this.matchPaymentMethodByText(methods, text);
+    if (matched) {
+      botUpdate.pendingExpense!.paymentMethodId = getDocumentId(matched);
+      botUpdate.markModified('pendingExpense');
+      botUpdate.state = ConversationState.CONFIRMING;
+      await botUpdate.save();
+      await this.showConfirmation(botUpdate, telegramUserId, boardId, methods);
+      return;
+    }
+
+    botUpdate.state = ConversationState.ASKING_EVERYDAY_PAYMENT;
+    await botUpdate.save();
+    await this.askForPaymentMethod(botUpdate, telegramUserId, methods);
+  }
+
+  private async askForCategory(
+    botUpdate: BotUpdateDocument,
+    telegramUserId: number,
+    categories: Category[],
+  ): Promise<void> {
+    if (categories.length === 0) {
+      await this.telegramClient.sendMessage(
+        telegramUserId,
+        '⚠️ No hay categorías en este tablero. Configuralas desde la web.',
+      );
+      botUpdate.state = ConversationState.IDLE;
+      botUpdate.pendingExpense = undefined;
+      await botUpdate.save();
+      return;
+    }
+
+    const message = '📂 ¿En qué categoría va este gasto?';
+    const buttons = categories.slice(0, 10).map((category) => ({
+      text: category.name,
+      callback_data: `everyday-category:${getDocumentId(category)}`,
+    }));
+
+    await this.telegramClient.sendMessageWithButtons(
+      telegramUserId,
+      message,
+      buttons,
+    );
+  }
+
+  private async askForPaymentMethod(
+    botUpdate: BotUpdateDocument,
+    telegramUserId: number,
+    methods: PaymentMethodEntity[],
+  ): Promise<void> {
+    if (methods.length === 0) {
+      const updated = await this.reloadBotUpdate(botUpdate._id.toString());
+      if (!updated?.pendingExpense) {
+        return;
+      }
+
+      updated.state = ConversationState.CONFIRMING;
+      await updated.save();
+      await this.showConfirmation(updated, telegramUserId, '', []);
+      return;
+    }
+
+    const message = '💳 ¿Con qué medio pagaste?';
+    const buttons = methods.slice(0, 10).map((method) => ({
+      text: method.lastFourDigits
+        ? `${method.name} (****${method.lastFourDigits})`
+        : method.name,
+      callback_data: `everyday-payment:${getDocumentId(method)}`,
+    }));
+
+    await this.telegramClient.sendMessageWithButtons(
+      telegramUserId,
+      message,
+      buttons,
+    );
+  }
+
+  private async showConfirmation(
+    botUpdate: BotUpdateDocument,
+    telegramUserId: number,
+    boardId: string,
+    methods: PaymentMethodEntity[],
+  ): Promise<void> {
+    const expense = botUpdate.pendingExpense;
+    if (!expense?.amount) {
+      return;
+    }
+
+    let categoryName = 'Sin categoría';
+    if (expense.categoryId && boardId) {
+      const categories = await this.categoriesService.findAllByBoard(
+        boardId,
+        botUpdate.userId!.toString(),
+      );
+      categoryName =
+        categories.find((c) => getDocumentId(c) === expense.categoryId)?.name ??
+        categoryName;
+    }
+
+    let paymentName = 'Efectivo (sin medio registrado)';
+    if (expense.paymentMethodId) {
+      const method = methods.find(
+        (m) => getDocumentId(m) === expense.paymentMethodId,
+      );
+      if (method) {
+        paymentName = method.lastFourDigits
+          ? `${method.name} (****${method.lastFourDigits})`
+          : method.name;
+      }
+    }
+
+    const amountLine = expense.currency
+      ? `💰 *Monto:* ${expense.amount} ${expense.currency}`
+      : `💰 *Monto:* ${expense.amount}`;
+
+    const message =
+      '📋 *Resumen del gasto (everyday):*\n\n' +
+      `${amountLine}\n` +
+      `📝 *Descripción:* ${expense.description || 'Sin descripción'}\n` +
+      `📂 *Categoría:* ${categoryName}\n` +
+      `💳 *Medio:* ${paymentName}`;
+
+    const buttons = [
+      { text: '✅ Confirmar', callback_data: 'everyday-confirm:yes' },
+      { text: '❌ Cancelar', callback_data: 'confirm:no' },
+    ];
+
+    await this.telegramClient.sendMessageWithButtons(
+      telegramUserId,
+      message,
+      buttons,
+    );
+  }
+
+  private matchCategoryByText(
+    categories: Category[],
+    text: string,
+  ): Category | undefined {
+    const normalized = text.toLowerCase();
+    return categories.find((category) =>
+      normalized.includes(category.name.toLowerCase()),
+    );
+  }
+
+  private matchPaymentMethodByText(
+    methods: PaymentMethodEntity[],
+    text: string,
+  ): PaymentMethodEntity | undefined {
+    const normalized = text.toLowerCase();
+    return methods.find((method) => {
+      const name = method.name.toLowerCase();
+      const digits = method.lastFourDigits ?? '';
+      return (
+        normalized.includes(name) ||
+        (digits.length > 0 && normalized.includes(digits))
+      );
+    });
+  }
+
+  private normalizeDescription(
+    parsedDescription: string | undefined,
+    fallbackText: string,
+  ): string {
+    const candidate = (parsedDescription || fallbackText)
+      .trim()
+      .substring(0, 500);
+    if (candidate.length >= 3) {
+      return candidate;
+    }
+    return 'Gasto registrado';
+  }
+
+  private reloadBotUpdate(id: string): Promise<BotUpdateDocument | null> {
+    return this.botUpdateModel.findById(id).exec();
+  }
+}

--- a/src/bot/linking/user-linking.service.ts
+++ b/src/bot/linking/user-linking.service.ts
@@ -31,12 +31,12 @@ export class UserLinkingService {
     if (parts.length === 1) {
       await this.telegramClient.sendMessage(
         telegramUserId,
-        '👋 ¡Hola! Soy el bot de FinanzApp Travels.\n\n' +
+        '👋 ¡Hola! Soy el bot de FinanzApp.\n\n' +
           'Para vincular tu cuenta:\n' +
-          '1. Inicia sesión en la web\n' +
+          '1. Iniciá sesión en la web\n' +
           '2. Ve a Configuración → Bot de Telegram\n' +
-          '3. Copia el token que se genera\n' +
-          '4. Envíame: /start <token>\n\n' +
+          '3. Copiá el token que se genera\n' +
+          '4. Enviame: /start <token>\n\n' +
           'Ejemplo: /start abc123xyz',
       );
       return;
@@ -116,8 +116,10 @@ export class UserLinkingService {
     await this.telegramClient.sendMessage(
       telegramUserId,
       '✅ ¡Cuenta vinculada exitosamente!\n\n' +
-        'Ahora puedes cargar gastos enviándome mensajes informales.\n' +
-        'Ejemplo: "Cena 120 usd compartido"',
+        '1. Elegí tu tablero activo con /board\n' +
+        '2. Cargá gastos con mensajes informales\n\n' +
+        'Ejemplo everyday: "Super 15000"\n' +
+        'Ejemplo viaje: "Cena 120 usd compartido"',
     );
   }
 

--- a/src/bot/repositories/bot-update.repository.ts
+++ b/src/bot/repositories/bot-update.repository.ts
@@ -6,14 +6,16 @@ import {
   BotUpdateDocument,
   ConversationState,
 } from '../bot-update.schema';
-import { TripsService } from '../../trips/trips.service';
+import { BoardsService } from '../../trips/trips.service';
+import { UserPreferencesService } from '../../users/user-preferences.service';
 
 @Injectable()
 export class BotUpdateRepository {
   constructor(
     @InjectModel(BotUpdate.name)
     public botUpdateModel: Model<BotUpdateDocument>,
-    private tripsService: TripsService,
+    private boardsService: BoardsService,
+    private userPreferencesService: UserPreferencesService,
   ) {}
 
   async getOrCreateBotUpdate(
@@ -34,43 +36,56 @@ export class BotUpdateRepository {
     return botUpdate;
   }
 
-  async determineActiveTrip(
+  async determineActiveBoardId(
     botUpdate: BotUpdateDocument,
   ): Promise<string | null> {
-    if (botUpdate.currentTripId) {
-      try {
-        await this.tripsService.findOne(
-          botUpdate.currentTripId.toString(),
-          botUpdate.userId!.toString(),
-        );
-        return botUpdate.currentTripId.toString();
-      } catch {
-        // Trip no longer valid, will search for another one below
-      }
-    }
-
-    const trips = await this.tripsService.findAll(botUpdate.userId!.toString());
-
-    if (trips.length === 0) {
+    if (!botUpdate.userId) {
       return null;
     }
 
-    if (trips.length === 1) {
-      const firstTrip = trips[0] as unknown as {
-        _id: Types.ObjectId;
-      } & Record<string, unknown>;
-      const tripId = firstTrip._id.toString();
-      botUpdate.currentTripId = new Types.ObjectId(tripId);
-      await botUpdate.save();
-      return tripId;
+    const userId = botUpdate.userId.toString();
+    const preferredId =
+      await this.userPreferencesService.getActiveBoardId(userId);
+
+    if (preferredId) {
+      try {
+        await this.boardsService.findOne(preferredId, userId);
+        botUpdate.currentTripId = new Types.ObjectId(preferredId);
+        await botUpdate.save();
+        return preferredId;
+      } catch {
+        await this.userPreferencesService.setActiveBoardId(userId, null);
+      }
     }
 
-    const mostRecentTrip = trips[0] as unknown as {
-      _id: Types.ObjectId;
-    } & Record<string, unknown>;
-    const tripId = mostRecentTrip._id.toString();
-    botUpdate.currentTripId = new Types.ObjectId(tripId);
+    if (botUpdate.currentTripId) {
+      try {
+        await this.boardsService.findOne(
+          botUpdate.currentTripId.toString(),
+          userId,
+        );
+        return botUpdate.currentTripId.toString();
+      } catch {
+        // stale session board
+      }
+    }
+
+    const boards = await this.boardsService.findAll(userId);
+    if (boards.length === 0) {
+      return null;
+    }
+
+    const firstBoard = boards[0] as unknown as { _id: Types.ObjectId };
+    const boardId = firstBoard._id.toString();
+    botUpdate.currentTripId = new Types.ObjectId(boardId);
     await botUpdate.save();
-    return tripId;
+    return boardId;
+  }
+
+  /** @deprecated Use determineActiveBoardId */
+  async determineActiveTrip(
+    botUpdate: BotUpdateDocument,
+  ): Promise<string | null> {
+    return this.determineActiveBoardId(botUpdate);
   }
 }

--- a/src/bot/utils/bot-helpers.ts
+++ b/src/bot/utils/bot-helpers.ts
@@ -29,3 +29,14 @@ export function getCardId(card: unknown): string {
   }
   return '';
 }
+
+export function getDocumentId(doc: unknown): string {
+  const value = doc as { _id?: Types.ObjectId | string; id?: string };
+  if (value._id) {
+    return typeof value._id === 'string' ? value._id : value._id.toString();
+  }
+  if (value.id) {
+    return value.id;
+  }
+  return '';
+}

--- a/src/users/dto/update-user-preferences.dto.ts
+++ b/src/users/dto/update-user-preferences.dto.ts
@@ -1,0 +1,8 @@
+import { IsMongoId, IsOptional, ValidateIf } from 'class-validator';
+
+export class UpdateUserPreferencesDto {
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsMongoId({ message: 'El ID del tablero activo no es válido' })
+  activeBoardId?: string | null;
+}

--- a/src/users/user-preferences.service.spec.ts
+++ b/src/users/user-preferences.service.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Types } from 'mongoose';
+import { UserPreferencesService } from './user-preferences.service';
+import { User } from './user.schema';
+import { BoardsService } from '../trips/trips.service';
+import { NotFoundException } from '@nestjs/common';
+
+describe('UserPreferencesService', () => {
+  let service: UserPreferencesService;
+
+  const userId = new Types.ObjectId().toString();
+  const boardId = new Types.ObjectId().toString();
+
+  const userModel = {
+    findById: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+  };
+
+  const boardsService = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserPreferencesService,
+        { provide: getModelToken(User.name), useValue: userModel },
+        { provide: BoardsService, useValue: boardsService },
+      ],
+    }).compile();
+
+    service = module.get(UserPreferencesService);
+  });
+
+  it('returns null when user has no active board', async () => {
+    userModel.findById.mockReturnValue({
+      select: jest.fn().mockResolvedValue({ activeBoardId: null }),
+    });
+
+    await expect(service.getActiveBoardId(userId)).resolves.toBeNull();
+  });
+
+  it('sets active board after validating access', async () => {
+    boardsService.findOne.mockResolvedValue({ _id: boardId });
+    userModel.findByIdAndUpdate.mockResolvedValue({});
+
+    await expect(service.setActiveBoardId(userId, boardId)).resolves.toBe(
+      boardId,
+    );
+
+    expect(boardsService.findOne).toHaveBeenCalledWith(boardId, userId);
+    expect(userModel.findByIdAndUpdate).toHaveBeenCalled();
+  });
+
+  it('clears invalid active board on resolve', async () => {
+    userModel.findById.mockReturnValue({
+      select: jest
+        .fn()
+        .mockResolvedValue({ activeBoardId: new Types.ObjectId(boardId) }),
+    });
+    boardsService.findOne.mockRejectedValue(new NotFoundException());
+    userModel.findByIdAndUpdate.mockResolvedValue({});
+
+    await expect(service.resolveActiveBoard(userId)).resolves.toBeNull();
+    expect(userModel.findByIdAndUpdate).toHaveBeenCalledWith(userId, {
+      $set: { activeBoardId: null },
+    });
+  });
+});

--- a/src/users/user-preferences.service.ts
+++ b/src/users/user-preferences.service.ts
@@ -1,0 +1,80 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { User, UserDocument } from './user.schema';
+import { BoardsService } from '../trips/trips.service';
+import { Board } from '../trips/board.schema';
+
+@Injectable()
+export class UserPreferencesService {
+  constructor(
+    @InjectModel(User.name) private userModel: Model<UserDocument>,
+    private boardsService: BoardsService,
+  ) {}
+
+  async getActiveBoardId(userId: string): Promise<string | null> {
+    const user = await this.userModel.findById(userId).select('activeBoardId');
+    if (!user?.activeBoardId) {
+      return null;
+    }
+    return user.activeBoardId.toString();
+  }
+
+  async setActiveBoardId(
+    userId: string,
+    boardId: string | null,
+  ): Promise<string | null> {
+    if (boardId === null) {
+      await this.userModel.findByIdAndUpdate(userId, {
+        $set: { activeBoardId: null },
+      });
+      return null;
+    }
+
+    await this.boardsService.findOne(boardId, userId);
+
+    await this.userModel.findByIdAndUpdate(userId, {
+      $set: { activeBoardId: new Types.ObjectId(boardId) },
+    });
+
+    return boardId;
+  }
+
+  async resolveActiveBoard(userId: string): Promise<Board | null> {
+    const activeBoardId = await this.getActiveBoardId(userId);
+    if (!activeBoardId) {
+      return null;
+    }
+
+    try {
+      return await this.boardsService.findOne(activeBoardId, userId);
+    } catch {
+      await this.setActiveBoardId(userId, null);
+      return null;
+    }
+  }
+
+  async requireUser(userId: string): Promise<UserDocument> {
+    const user = await this.userModel.findById(userId).exec();
+    if (!user) {
+      throw new NotFoundException('Usuario no encontrado');
+    }
+    return user;
+  }
+
+  async updatePreferences(
+    userId: string,
+    activeBoardId?: string | null,
+  ): Promise<{ activeBoardId: string | null }> {
+    if (activeBoardId === undefined) {
+      throw new BadRequestException('No hay preferencias para actualizar');
+    }
+
+    const resolved = await this.setActiveBoardId(userId, activeBoardId);
+    return { activeBoardId: resolved };
+  }
+}

--- a/src/users/user.schema.ts
+++ b/src/users/user.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { Document, Types } from 'mongoose';
 import * as bcrypt from 'bcrypt';
 
 @Schema({ timestamps: true })
@@ -48,6 +48,10 @@ export class User {
 
   @Prop({ type: Number, unique: true, sparse: true })
   telegramUserId?: number;
+
+  /** Active board for Telegram bot and web (shared preference). */
+  @Prop({ type: Types.ObjectId, ref: 'Board', default: null })
+  activeBoardId?: Types.ObjectId | null;
 }
 
 export type UserDocument = User &

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,15 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { User, UserSchema } from './user.schema';
+import { UserPreferencesService } from './user-preferences.service';
+import { BoardsModule } from '../trips/trips.module';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+    forwardRef(() => BoardsModule),
+  ],
+  providers: [UserPreferencesService],
+  exports: [UserPreferencesService, MongooseModule],
+})
+export class UsersModule {}


### PR DESCRIPTION
## Summary

- Persiste `activeBoardId` en el usuario y expone `PATCH /auth/preferences` + `GET /auth/me` con el tablero activo (usable por web y bot).
- Comando `/board` para listar y cambiar tablero activo; onboarding del bot actualizado (ya no solo “viaje”).
- Flujo **everyday** corto: monto → categoría → medio de pago → confirmación.
- Flujo **travel** existente reutilizado cuando el tablero activo es `travel` (presupuesto/split).
- Sin tablero activo: el bot indica cómo elegir uno con `/board` (no crashea).

Closes #10

## Self-review (Developer)

- Commit: `6119b14`
- Bugbot: 3 findings (1 high, 2 medium) — resueltos: `markModified('pendingExpense')`, reset de conversación al cambiar tablero, descripción mínima normalizada
- Security: sin issues medium/high

## Cómo probarlo

1. **Backend local**
   ```bash
   cd finanzapp-travels-backend
   npm run start:dev
   ```
   Variables: `MONGODB_URI`, `JWT_SECRET`, `TELEGRAM_BOT_TOKEN` (y `GROQ_API_KEY` opcional).

2. **Vincular cuenta**
   - Login en la web → generar token (`POST /api/bot/generate-link-token` con JWT).
   - En Telegram: `/start <token>`.

3. **Elegir tablero**
   - `/board` → lista con botones; elegir tablero everyday.
   - Verificar `GET /api/auth/me` devuelve `activeBoardId`.

4. **Gasto everyday**
   - Enviar: `Super 15000` → elegir categoría y medio → Confirmar.
   - Verificar gasto en `GET /api/expenses?boardId=<id>`.

5. **Gasto travel**
   - `/board` → elegir tablero travel.
   - Enviar: `Cena 120 usd compartido` → flujo presupuesto/split existente.

6. **Sin tablero activo**
   - `PATCH /api/auth/preferences` con `{ "activeBoardId": null }`.
   - Enviar un gasto → mensaje pidiendo `/board`.

7. **Reset**
   - `/reset` limpia estado conversacional.

## Requiere antes de deploy

Ninguno (campo `activeBoardId` se agrega con default `null`; sin migración manual).

## Notas para el reviewer

- `botUpdate.currentTripId` se mantiene como alias de sesión del tablero activo en el bot (compat con flujo travel).
- Los callbacks `everyday-category:` / `everyday-payment:` confían en validación final de `ExpensesService.create`.
- Income por chat quedó fuera de alcance (opcional en el issue).