### PR TITLE
[Issue #11] Branding/infra rename + bot nuevo (coordinar DevOps)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ JWT_REFRESH_EXPIRES_IN=7d
 # Server
 PORT=8080
 NODE_ENV=development
+
+# SPA origin for CORS (production: set to https://your-app.example.com, no trailing slash)
+# Also used in transactional email links. See docs/branding-rename-checklist.md when changing hostnames.
 FRONTEND_URL=http://localhost:5173
 
 # Email (optional)
@@ -21,8 +24,11 @@ SMTP_SECURE=false
 SMTP_FROM=
 APP_NAME=FinanzApp
 
-# Telegram bot (optional)
+# Telegram bot (optional in local dev; required for link + expense flows)
+# Production: fly secrets set TELEGRAM_BOT_TOKEN / WEBHOOK_URL — never commit real tokens.
+# Bot migration Travels → FinanzApp: docs/branding-rename-checklist.md + docs/adr/002-branding-rename-infra.md
 TELEGRAM_BOT_TOKEN=
+# Full URL to POST /api/bot/webhook (e.g. https://finanzapp-travels-backend.fly.dev/api/bot/webhook)
 WEBHOOK_URL=
 
 # LLM parser for Telegram (optional)

--- a/docs/adr/002-branding-rename-infra.md
+++ b/docs/adr/002-branding-rename-infra.md
@@ -1,0 +1,80 @@
+# ADR 002: Branding rename Travels → FinanzApp (infra y bot)
+
+## Status
+
+Accepted (2026-08-01)
+
+## Context
+
+The product evolved from a travel-expense app ("FinanzApp Travels") to a general
+personal-finance app centered on **boards** (`everyday` and `travel`). The MVP
+backend and frontend already use "FinanzApp" in user-facing copy, emails, and bot
+messages, but infrastructure identifiers still carry the legacy name:
+
+| Layer             | Current identifier                                        | Notes                                   |
+| ----------------- | --------------------------------------------------------- | --------------------------------------- |
+| Fly.io app        | `finanzapp-travels-backend`                               | `fly.toml`, default webhook URL in code |
+| GitHub repos      | `finanzapp-travels-backend`, `finanzapp-travels-frontend` | Out of scope for this ADR               |
+| Telegram bot      | Legacy username (e.g. `@…TravelsBot`)                     | Single `TELEGRAM_BOT_TOKEN` per deploy  |
+| PWA manifest (FE) | `name: "FinanzApp Travels"`                               | Addressed in frontend issue #10         |
+| CORS              | `FRONTEND_URL` secret on Fly                              | Must include production SPA origin      |
+
+DevOps recommended **not** renaming the Fly app name early: it implies DNS,
+certificates, webhook URLs, and secret rotation with little user-visible benefit
+while the public URL can stay stable.
+
+## Decision
+
+### 1. Fly.io app name — keep for v1 rename
+
+- **Keep** `finanzapp-travels-backend` as the Fly app name for the first branding
+  rollout.
+- Set `WEBHOOK_URL` explicitly in Fly secrets so the default hardcoded host in
+  `TelegramClientService` is not relied upon in production.
+- Revisit Fly rename (or a new app + cutover) only when:
+  - a new public API hostname is required, or
+  - the legacy name causes operational confusion for the team.
+
+### 2. Telegram bot — new bot, phased cutover
+
+- Register a **new** bot via BotFather with FinanzApp branding (username, name,
+  description, `/setabout`, `/setuserpic`).
+- Deploy the new `TELEGRAM_BOT_TOKEN` to staging first, then production.
+- **Do not** commit tokens; store only in Fly secrets / CI secret store.
+- Retire the legacy bot after a documented grace period (see
+  `docs/branding-rename-checklist.md`).
+
+### 3. CORS and frontend URL
+
+- Production `FRONTEND_URL` must match the deployed SPA origin (scheme + host,
+  no trailing slash). The API allows localhost origins in development
+  (`src/main.ts`).
+- When the frontend hostname changes, update the Fly secret **before** switching
+  DNS to the new SPA.
+
+### 4. Coordination with frontend
+
+- Backend checklist (this repo, issue #11) covers secrets, webhook, CORS, and bot
+  migration.
+- Frontend issue #10 covers UI strings, `index.html`, and PWA manifest
+  `name` / `short_name`.
+- Deploy order: staging bot + API secrets → FE staging → validate link flow →
+  production bot token swap → FE production → legacy bot deprecation messages.
+
+## Consequences
+
+- Operators follow `docs/branding-rename-checklist.md` for rollout; no product
+  code changes are required in this ADR beyond documentation and `.env.example`
+  comments.
+- Users may see "Travels" in the PWA install name until frontend #10 ships; API
+  and emails already say FinanzApp.
+- Legacy Telegram users must re-link only if chat IDs differ between bots;
+  linking is per `telegramUserId` on the User document — migrating to a new bot
+  does not invalidate existing links as long as the same backend DB is used.
+
+## References
+
+- `docs/branding-rename-checklist.md` — operational checklist
+- `.env.example` — required secrets and comments
+- `fly.toml` — current Fly app name
+- Frontend: `frangiuliano/finanzapp-travels-frontend` issue #10

--- a/docs/branding-rename-checklist.md
+++ b/docs/branding-rename-checklist.md
@@ -1,0 +1,190 @@
+# Checklist: rename Travels → FinanzApp (DevOps / backend)
+
+Operational checklist for issue **#11**. Pair with frontend issue **#10** (UI/PWA
+manifest) and ADR `docs/adr/002-branding-rename-infra.md`.
+
+**Rule:** never commit real tokens, API keys, or production URLs with secrets.
+
+---
+
+## 1. Decisions (sign-off before changes)
+
+| Item                        | Recommendation                                                       | Owner            | Done |
+| --------------------------- | -------------------------------------------------------------------- | ---------------- | ---- |
+| Fly app name                | **Keep** `finanzapp-travels-backend` for v1 (see ADR 002)            | DevOps           | ☐    |
+| New Telegram bot username   | Register via BotFather (e.g. `@FinanzAppBot` — confirm availability) | Product + DevOps | ☐    |
+| Production SPA URL          | Confirm canonical `https://…` for `FRONTEND_URL`                     | DevOps           | ☐    |
+| Grace period for legacy bot | Suggest **90 days** after new bot is live                            | Product          | ☐    |
+| Coordinate FE deploy        | FE #10 merged before or with bot go-live                             | Dev              | ☐    |
+
+---
+
+## 2. New Telegram bot (BotFather)
+
+| Step | Action                                                                     | Done |
+| ---- | -------------------------------------------------------------------------- | ---- |
+| 2.1  | `/newbot` → name **FinanzApp**, username without "Travels"                 | ☐    |
+| 2.2  | `/setdescription` — everyday + travel boards, link from web app            | ☐    |
+| 2.3  | `/setabout` — short tagline + link to web                                  | ☐    |
+| 2.4  | `/setuserpic` — FinanzApp icon (match PWA, FE #10)                         | ☐    |
+| 2.5  | `/setcommands` — align with bot handlers (`/start`, `/board`, `/reset`, …) | ☐    |
+| 2.6  | Save token in password manager; **do not** commit to git                   | ☐    |
+
+Suggested `/setcommands` (adjust to match shipped handlers):
+
+```
+start - Vincular cuenta o ver ayuda
+board - Ver o cambiar tablero activo
+reset - Cancelar conversación en curso
+```
+
+---
+
+## 3. Fly.io secrets (staging → production)
+
+Apply on the `finanzapp-travels-backend` app (or staging app if split).
+
+```bash
+# Staging example — replace placeholders
+fly secrets set \
+  TELEGRAM_BOT_TOKEN="<new-bot-token>" \
+  WEBHOOK_URL="https://<api-host>/api/bot/webhook" \
+  FRONTEND_URL="https://<spa-host>" \
+  -a finanzapp-travels-backend
+```
+
+| Secret                              | Purpose                                      | Done |
+| ----------------------------------- | -------------------------------------------- | ---- |
+| `TELEGRAM_BOT_TOKEN`                | New FinanzApp bot token                      | ☐    |
+| `WEBHOOK_URL`                       | Full HTTPS URL to `POST /api/bot/webhook`    | ☐    |
+| `FRONTEND_URL`                      | Production SPA origin for CORS + email links | ☐    |
+| `APP_NAME`                          | Optional; defaults to `FinanzApp` in emails  | ☐    |
+| `JWT_SECRET` / `JWT_REFRESH_SECRET` | Unchanged unless rotating                    | ☐    |
+| `MONGODB_URI`                       | Unchanged                                    | ☐    |
+| `FX_API_KEY`, `GROQ_API_KEY`, SMTP  | Unchanged unless rotating                    | ☐    |
+
+After deploy, verify logs show `✅ Webhook configurado: <WEBHOOK_URL>`.
+
+Local dev: copy `.env.example` → `.env` and set the same variable names (use a
+**test** bot token, not production).
+
+---
+
+## 4. CORS validation
+
+| Check                | How                                                                                                | Done |
+| -------------------- | -------------------------------------------------------------------------------------------------- | ---- |
+| SPA origin allowed   | Browser login from production URL; no CORS error on `/api/auth/*`                                  | ☐    |
+| Credentials          | Cookies / `withCredentials` work for authenticated routes                                          | ☐    |
+| New preview hostname | If using Vercel preview, add origin to `FRONTEND_URL` or extend allowlist in code (separate issue) | ☐    |
+
+Allowed origins are built in `src/main.ts`: localhost ports + `FRONTEND_URL`.
+
+---
+
+## 5. Webhook and health
+
+| Check              | Command / action                                            | Expected                          | Done |
+| ------------------ | ----------------------------------------------------------- | --------------------------------- | ---- |
+| Health             | `GET https://<api-host>/api/health`                         | 200                               | ☐    |
+| Webhook registered | `curl "https://api.telegram.org/bot<TOKEN>/getWebhookInfo"` | `url` matches `WEBHOOK_URL`       | ☐    |
+| Link flow          | Web → Cuenta → generate token → `/start <token>` in new bot | User linked, confirmation message | ☐    |
+| Expense flow       | Send everyday expense message                               | Expense on active board in API    | ☐    |
+| Board switch       | `/board` in Telegram                                        | Lists boards, sets active         | ☐    |
+
+---
+
+## 6. Legacy bot → new bot coexistence plan
+
+### Phase A — Preparation (T-7 days)
+
+| Action                                                                                     | Done |
+| ------------------------------------------------------------------------------------------ | ---- |
+| New bot created; token in staging only                                                     | ☐    |
+| FE #10 on staging (manifest shows **FinanzApp**)                                           | ☐    |
+| Update **legacy** bot via BotFather: description mentions migration date + new `@username` | ☐    |
+| Optional: pin message on legacy bot channel/group docs with new bot link                   | ☐    |
+
+### Phase B — Go-live (T0)
+
+| Action                                                                | Done |
+| --------------------------------------------------------------------- | ---- |
+| Deploy backend with **new** `TELEGRAM_BOT_TOKEN` to production        | ☐    |
+| Deploy frontend #10 to production                                     | ☐    |
+| Smoke tests (section 5) on production                                 | ☐    |
+| Announce in-app / email: "Nuevo bot de Telegram" with `@new_username` | ☐    |
+
+### Phase C — Legacy deprecation (T0 → T+90)
+
+The backend serves **one** bot token per environment. The legacy bot cannot use
+the new handlers unless its token is still wired to the API. Recommended approach:
+
+1. **Immediately after cutover:** remove webhook from legacy bot so it stops
+   processing expenses:
+
+   ```bash
+   curl -X POST "https://api.telegram.org/bot<LEGACY_TOKEN>/deleteWebhook"
+   ```
+
+2. **BotFather (legacy bot):** set description and about to point users to the new
+   bot and the web app. Telegram will show this when users open the old chat.
+
+3. **Optional lightweight deprecation webhook** (if product wants auto-replies):
+   deploy a minimal endpoint (separate Fly app or serverless) with **only** the
+   legacy token that responds to any message with:
+
+   ```
+   ⚠️ Este bot fue reemplazado por FinanzApp.
+
+   Usá el bot nuevo: @<NEW_BOT_USERNAME>
+   Vinculá tu cuenta desde la web: Configuración → Bot de Telegram.
+
+   Este chat ya no registra gastos.
+   ```
+
+   Do **not** store the legacy token in this repository.
+
+4. **User data:** existing `telegramUserId` links in MongoDB remain valid for the
+   new bot (same user IDs). Users only need a new `/start <token>` if they never
+   linked on the new bot.
+
+### Phase D — Retirement (T+90)
+
+| Action                                          | Done |
+| ----------------------------------------------- | ---- |
+| Remove legacy bot deprecation endpoint (if any) | ☐    |
+| Revoke / delete legacy bot token in BotFather   | ☐    |
+| Remove legacy token from any secret store       | ☐    |
+| Archive this checklist with dates filled in     | ☐    |
+
+---
+
+## 7. `.env.example` and documentation
+
+| Item                                                                         | Done |
+| ---------------------------------------------------------------------------- | ---- |
+| `.env.example` documents `TELEGRAM_BOT_TOKEN`, `WEBHOOK_URL`, `FRONTEND_URL` | ☐    |
+| ADR 002 merged (`docs/adr/002-branding-rename-infra.md`)                     | ☐    |
+| This checklist merged                                                        | ☐    |
+| No secrets in git history for this PR                                        | ☐    |
+
+---
+
+## 8. Out of scope (explicit)
+
+- Renaming GitHub repositories or Fly app (deferred per ADR 002).
+- Frontend UI copy / PWA manifest (frontend #10).
+- Offline expense queue (backend #12).
+- New product features.
+
+---
+
+## Rollback
+
+If the new bot misbehaves after go-live:
+
+1. `fly secrets set TELEGRAM_BOT_TOKEN="<previous-token>"` and redeploy.
+2. Re-register webhook for the previous token if it was deleted.
+3. Revert FE deploy if manifest/copy changes cause issues.
+
+Document incident date and root cause in this file or a postmortem issue.


### PR DESCRIPTION
## Summary

- ADR `docs/adr/002-branding-rename-infra.md`: decisión de mantener el nombre Fly `finanzapp-travels-backend` en v1, nuevo bot Telegram, CORS y orden de deploy con FE #10.
- Checklist operativo `docs/branding-rename-checklist.md`: secrets Fly, webhook, validación CORS, fases de convivencia bot viejo → nuevo (incl. mensaje de deprecación y rollback).
- Comentarios en `.env.example` para `FRONTEND_URL`, `TELEGRAM_BOT_TOKEN` y `WEBHOOK_URL` (sin secretos).

Closes #11

## Self-review (Developer)

- Commit: `b0fc5adedc6d01abedd132fc6d6cef46c138281f`
- Bugbot: sin issues
- Security: sin issues (medium/high)

## Cómo probarlo

1. Clonar la rama y abrir `docs/branding-rename-checklist.md`.
2. Verificar que las secciones 1–8 cubren: decisión Fly, bot nuevo, secrets, CORS, webhook, plan de deprecación del bot legacy y rollback.
3. Leer `docs/adr/002-branding-rename-infra.md` y confirmar que documenta no renombrar Fly en v1 y coordinación con frontend #10.
4. Revisar `.env.example`: comentarios de migración sin valores reales de tokens.
5. `npm run lint && npm run test && npm run build` — deben pasar (sin cambios de código de producto).

## Requiere antes de deploy

Ninguno (solo documentación). La ejecución del checklist requiere secrets en Fly (`TELEGRAM_BOT_TOKEN`, `WEBHOOK_URL`, `FRONTEND_URL`) fuera del repo.

## Notas para el reviewer

- Issue de alcance chore/v1: no hay cambios de API ni bot handlers.
- Coordinar merge con frontend #10 antes del go-live de branding en producción.
- El checklist sugiere 90 días de gracia para el bot legacy; ajustable por producto.