### PR TITLE
[Issue #12] Offline queue de gastos (post-MVP)

### DIFF
--- a/docs/adr/003-offline-expense-queue.md
+++ b/docs/adr/003-offline-expense-queue.md
@@ -1,0 +1,65 @@
+# ADR 003: Offline expense queue and idempotency
+
+## Status
+
+Accepted
+
+## Context
+
+Users capture expenses on mobile PWA where connectivity is intermittent. The MVP
+ships synchronous `POST /expenses` only. Post-MVP (v1) we need:
+
+- Queue expense creates client-side when offline or on transient network failure
+- Sync when connectivity returns without duplicating rows in MongoDB
+- Predictable conflict behaviour for retries
+
+## Decision
+
+### Client queue (frontend)
+
+- Persist pending creates in **IndexedDB** (`finanzapp-offline` / `expense-queue`)
+- Each enqueue generates a **UUID v4** (`clientRequestId`) before any network call
+- On submit: try online POST; on offline / network error → enqueue locally and
+  show success toast (“se sincronizará al volver la conexión”)
+- `online` event + app mount trigger FIFO sync (stop on first hard failure to
+  preserve order)
+- Only **create** is queued; updates/deletes remain online-only (out of scope)
+
+### Idempotency (backend)
+
+- `CreateExpenseDto.clientRequestId` (optional UUID v4) and HTTP header
+  `Idempotency-Key` (alias; body wins if both sent)
+- Store `clientRequestId` on `Expense` with unique partial index
+  `{ createdBy, clientRequestId }`
+- `ExpensesService.create`: if key exists for user → return existing expense
+  (no second budget increment)
+- Concurrent duplicate inserts catch MongoDB `E11000` and return existing row
+
+### FX and budgets on replay
+
+- Idempotent replay returns the **original** persisted expense (FX snapshot from
+  first successful write). Retries must not recalculate FX or touch budget twice.
+
+## Conflict policy (basic)
+
+| Scenario                           | Behaviour                                                   |
+| ---------------------------------- | ----------------------------------------------------------- |
+| Same `clientRequestId` retried     | Return existing expense (200 semantics via 201 + same body) |
+| Different payload, same key        | Rejected by unique index + first-write-wins on replay       |
+| Board/category deleted before sync | Sync fails with 4xx; item stays in queue with `lastError`   |
+| Auth expired during sync           | Refresh flow runs; if still 401, item remains queued        |
+
+Full bidirectional sync / CRDT is explicitly out of scope.
+
+## Consequences
+
+- **Positive:** Safe offline capture; no duplicate expenses on flaky networks
+- **Negative:** Queued items may fail permanently if server state changed; user
+  must retry manually after fixing data
+- **Ops:** No migration for legacy rows (`clientRequestId` optional / sparse index)
+
+## References
+
+- Global backlog G-21 / backend issue #12
+- Frontend: `src/services/offlineExpenseQueue.ts`,
+  `src/services/createExpenseWithOffline.ts`

--- a/src/expenses/dto/create-expense.dto.ts
+++ b/src/expenses/dto/create-expense.dto.ts
@@ -9,6 +9,7 @@ import {
   IsBoolean,
   ValidateNested,
   IsIn,
+  IsUUID,
   Min,
   MinLength,
   MaxLength,
@@ -125,4 +126,8 @@ export class CreateExpenseDto {
   @IsOptional()
   @IsString()
   expenseDate?: string;
+
+  @IsOptional()
+  @IsUUID('4', { message: 'clientRequestId debe ser un UUID v4 válido' })
+  clientRequestId?: string;
 }

--- a/src/expenses/expense.schema.ts
+++ b/src/expenses/expense.schema.ts
@@ -128,6 +128,10 @@ export class Expense {
   @Prop({ type: Types.ObjectId, ref: 'User', required: true })
   createdBy: Types.ObjectId;
 
+  /** Client-generated UUID for offline sync idempotency (unique per user). */
+  @Prop({ type: String, required: false, maxlength: 36 })
+  clientRequestId?: string;
+
   @Prop({ type: Date, default: Date.now })
   expenseDate: Date;
 
@@ -154,3 +158,12 @@ ExpenseSchema.index({ expenseDate: -1 });
 ExpenseSchema.index({ cardId: 1 });
 ExpenseSchema.index({ categoryId: 1 });
 ExpenseSchema.index({ paymentMethodId: 1 });
+ExpenseSchema.index(
+  { createdBy: 1, clientRequestId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      clientRequestId: { $exists: true, $type: 'string' },
+    },
+  },
+);

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -10,6 +10,7 @@ import {
   HttpStatus,
   UseGuards,
   Query,
+  Headers,
   BadRequestException,
 } from '@nestjs/common';
 import { ExpensesService } from './expenses.service';
@@ -29,7 +30,12 @@ export class ExpensesController {
   async create(
     @Body() createExpenseDto: CreateExpenseDto,
     @GetUser('_id') userId: string,
+    @Headers('idempotency-key') idempotencyKey?: string,
   ) {
+    if (idempotencyKey && !createExpenseDto.clientRequestId) {
+      createExpenseDto.clientRequestId = idempotencyKey;
+    }
+
     const expense = await this.expensesService.create(createExpenseDto, userId);
     return {
       message: 'Gasto creado exitosamente',

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -13,6 +13,7 @@ import {
   Headers,
   BadRequestException,
 } from '@nestjs/common';
+import { isUUID } from 'class-validator';
 import { ExpensesService } from './expenses.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
@@ -32,8 +33,15 @@ export class ExpensesController {
     @GetUser('_id') userId: string,
     @Headers('idempotency-key') idempotencyKey?: string,
   ) {
-    if (idempotencyKey && !createExpenseDto.clientRequestId) {
-      createExpenseDto.clientRequestId = idempotencyKey;
+    if (idempotencyKey) {
+      if (!isUUID(idempotencyKey, '4')) {
+        throw new BadRequestException(
+          'Idempotency-Key debe ser un UUID v4 válido',
+        );
+      }
+      if (!createExpenseDto.clientRequestId) {
+        createExpenseDto.clientRequestId = idempotencyKey;
+      }
     }
 
     const expense = await this.expensesService.create(createExpenseDto, userId);

--- a/src/expenses/expenses.idempotency.spec.ts
+++ b/src/expenses/expenses.idempotency.spec.ts
@@ -88,6 +88,7 @@ describe('ExpensesService idempotency', () => {
       lean: jest.fn().mockResolvedValue(existingLean),
     };
     expenseModel.findOne.mockReturnValue(chain);
+    participantModel.findOne.mockResolvedValue({ _id: participantId });
 
     const result = await service.create(
       {

--- a/src/expenses/expenses.idempotency.spec.ts
+++ b/src/expenses/expenses.idempotency.spec.ts
@@ -1,0 +1,112 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Types } from 'mongoose';
+import { ExpensesService } from './expenses.service';
+import { Expense } from './expense.schema';
+import { Budget } from '../budgets/budget.schema';
+import { Participant } from '../participants/schemas/participant.schema';
+import { BoardsService } from '../trips/trips.service';
+import { CategoriesService } from '../categories/categories.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+import { FxService } from '../fx/fx.service';
+
+describe('ExpensesService idempotency', () => {
+  let service: ExpensesService;
+
+  const boardId = new Types.ObjectId();
+  const participantId = new Types.ObjectId();
+  const userId = new Types.ObjectId().toString();
+  const clientRequestId = '550e8400-e29b-41d4-a716-446655440000';
+  const existingExpenseId = new Types.ObjectId();
+
+  const existingLean = {
+    _id: existingExpenseId,
+    tripId: boardId,
+    amount: 42,
+    currency: 'USD',
+    description: 'Offline cafe',
+    clientRequestId,
+    paidByParticipantId: participantId,
+    createdBy: new Types.ObjectId(userId),
+    status: 'paid',
+    paymentMethod: 'cash',
+    isDivisible: false,
+    expenseDate: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const expenseModel = {
+    findOne: jest.fn(),
+    findById: jest.fn(),
+    prototype: { save: jest.fn() },
+  };
+
+  const budgetModel = { findById: jest.fn(), findByIdAndUpdate: jest.fn() };
+  const participantModel = { findOne: jest.fn(), find: jest.fn() };
+
+  const boardsService = {
+    findByIdOrFail: jest.fn(),
+    assertTravelFeatures: jest.fn(),
+    isTravelBoard: jest.fn(),
+  };
+
+  const categoriesService = { findOne: jest.fn() };
+  const paymentMethodsService = { findAvailableForBoard: jest.fn() };
+  const fxService = {
+    resolveSnapshot: jest.fn().mockResolvedValue({
+      fxRateToBoardCurrency: 1,
+      fxCapturedAt: new Date(),
+    }),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExpensesService,
+        { provide: getModelToken(Expense.name), useValue: expenseModel },
+        { provide: getModelToken(Budget.name), useValue: budgetModel },
+        {
+          provide: getModelToken(Participant.name),
+          useValue: participantModel,
+        },
+        { provide: BoardsService, useValue: boardsService },
+        { provide: CategoriesService, useValue: categoriesService },
+        { provide: PaymentMethodsService, useValue: paymentMethodsService },
+        { provide: FxService, useValue: fxService },
+      ],
+    }).compile();
+
+    service = module.get(ExpensesService);
+  });
+
+  it('returns existing expense when clientRequestId already exists', async () => {
+    const chain = {
+      populate: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue(existingLean),
+    };
+    expenseModel.findOne.mockReturnValue(chain);
+
+    const result = await service.create(
+      {
+        boardId: boardId.toString(),
+        amount: 99,
+        description: 'Different amount',
+        clientRequestId,
+      },
+      userId,
+    );
+
+    expect(expenseModel.findOne).toHaveBeenCalledWith({
+      clientRequestId,
+      createdBy: new Types.ObjectId(userId),
+    });
+    expect(boardsService.findByIdOrFail).not.toHaveBeenCalled();
+    expect(result.amount).toBe(42);
+    expect((result as { clientRequestId?: string }).clientRequestId).toBe(
+      clientRequestId,
+    );
+  });
+});

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -302,6 +302,10 @@ export class ExpensesService implements OnModuleInit {
         userId,
       );
       if (existing) {
+        await this.assertUserIsBoardParticipant(
+          this.resolveBoardIdFromExpense(existing),
+          userId,
+        );
         this.logger.log(
           `Idempotent replay for clientRequestId=${clientRequestId} (user ${userId})`,
         );
@@ -549,6 +553,10 @@ export class ExpensesService implements OnModuleInit {
           userId,
         );
         if (existing) {
+          await this.assertUserIsBoardParticipant(
+            this.resolveBoardIdFromExpense(existing),
+            userId,
+          );
           return existing;
         }
       }
@@ -674,6 +682,22 @@ export class ExpensesService implements OnModuleInit {
     }
 
     return this.transformExpense(expense);
+  }
+
+  private async assertUserIsBoardParticipant(
+    boardId: string,
+    userId: string,
+  ): Promise<void> {
+    const userParticipant = await this.participantModel.findOne({
+      tripId: new Types.ObjectId(boardId),
+      userId: new Types.ObjectId(userId),
+    });
+
+    if (!userParticipant) {
+      throw new ForbiddenException(
+        'No tienes acceso a este tablero o el tablero no existe',
+      );
+    }
   }
 
   async update(
@@ -1853,5 +1877,21 @@ export class ExpensesService implements OnModuleInit {
       'code' in error &&
       (error as { code?: number }).code === 11000
     );
+  }
+
+  private resolveBoardIdFromExpense(expense: Expense): string {
+    const record = expense as unknown as {
+      boardId?: string;
+      tripId?: string | Types.ObjectId;
+    };
+    if (record.boardId) {
+      return record.boardId;
+    }
+    if (!record.tripId) {
+      return '';
+    }
+    return typeof record.tripId === 'string'
+      ? record.tripId
+      : record.tripId.toString();
   }
 }

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -294,6 +294,21 @@ export class ExpensesService implements OnModuleInit {
     createExpenseDto: CreateExpenseDto,
     userId: string,
   ): Promise<Expense> {
+    const clientRequestId = createExpenseDto.clientRequestId;
+
+    if (clientRequestId) {
+      const existing = await this.findExistingByClientRequestId(
+        clientRequestId,
+        userId,
+      );
+      if (existing) {
+        this.logger.log(
+          `Idempotent replay for clientRequestId=${clientRequestId} (user ${userId})`,
+        );
+        return existing;
+      }
+    }
+
     const boardId = resolveBoardId(createExpenseDto);
     if (!boardId) {
       throw new BadRequestException('boardId o tripId es requerido');
@@ -520,10 +535,25 @@ export class ExpensesService implements OnModuleInit {
       splits: processedSplits,
       status,
       createdBy: new Types.ObjectId(userId),
+      clientRequestId,
       expenseDate,
     });
 
-    const savedExpense = await expense.save();
+    let savedExpense: ExpenseDocument;
+    try {
+      savedExpense = await expense.save();
+    } catch (error) {
+      if (clientRequestId && this.isDuplicateKeyError(error)) {
+        const existing = await this.findExistingByClientRequestId(
+          clientRequestId,
+          userId,
+        );
+        if (existing) {
+          return existing;
+        }
+      }
+      throw error;
+    }
 
     if (createExpenseDto.budgetId) {
       const amountForBudget = this.getBudgetAmountForExpense(
@@ -1795,5 +1825,33 @@ export class ExpensesService implements OnModuleInit {
     await this.budgetModel.findByIdAndUpdate(budgetId, {
       $inc: { spent: amountChange },
     });
+  }
+
+  private async findExistingByClientRequestId(
+    clientRequestId: string,
+    userId: string,
+  ): Promise<Expense | null> {
+    const populatedExpense = await this.expenseModel
+      .findOne({
+        clientRequestId,
+        createdBy: new Types.ObjectId(userId),
+      })
+      .populate(EXPENSE_RELATION_POPULATES)
+      .lean();
+
+    if (!populatedExpense) {
+      return null;
+    }
+
+    return this.transformExpense(populatedExpense);
+  }
+
+  private isDuplicateKeyError(error: unknown): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: number }).code === 11000
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Add `clientRequestId` / `Idempotency-Key` idempotency on `POST /expenses` with unique index per user.
- Return existing expense on replay without duplicating budget updates; enforce board access on replay.
- Document offline queue design and conflict policy in ADR 003.

Closes #12

## Self-review (Developer)

- Commit: `7fe969d83dc61a7396c33cb7c2b943f67dea3fcd`
- Bugbot: sin issues
- Security: 1 medium resuelto (bypass de revocación en replay idempotente + validación UUID del header)

## Cómo probarlo

1. Backend: `npm run start:dev` con MongoDB local.
2. Crear gasto con header `Idempotency-Key: <uuid-v4>` y body normal.
3. Repetir el mismo POST → debe devolver el mismo gasto (sin duplicar en DB).
4. Repetir con otro UUID → crea un gasto nuevo.
5. `npm run test` incluye `expenses.idempotency.spec.ts`.

## Requiere antes de deploy

Ninguno (índice sparse se crea al arrancar Mongoose). Coordinar deploy con PR frontend del mismo branch name.

## Notas para el reviewer

- El replay idempotente valida participación activa en el tablero antes de devolver el gasto.
- FX y presupuesto quedan con el snapshot del primer write exitoso (ADR 003).