### PR TITLE
ci: add Fly.io deploy workflow triggered after successful CI on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to Fly.io
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-fly-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tested commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
### Motivation

- Automatizar despliegues a Fly.io cuando código probado llega a `main` sin reemplazar el CI existente.
- Garantizar que solo commits validados por la pipeline `CI` (lint/tests/build) se desplieguen.
- Evitar exponer credenciales en el repo y prevenir despliegues concurrentes de versiones diferentes.

### Description

- Se añadió el archivo `/.github/workflows/deploy.yml` que crea un workflow independiente llamado `Deploy to Fly.io`.
- El workflow se activa con `workflow_run` cuando el workflow `CI` termina (`types: [completed]`) y solo para ejecuciones originadas desde `main`.
- El job comprueba que `github.event.workflow_run.conclusion == 'success'`, que el evento original fue `push` y que la `head_branch` es `main`, y hace `checkout` del `head_sha` probado con `actions/checkout@v4` para desplegar precisamente el commit validado.
- Se configura `flyctl` con la acción `superfly/flyctl-actions/setup-flyctl@master` y se ejecuta `flyctl deploy --remote-only` usando `FLY_API_TOKEN` desde `${{ secrets.FLY_API_TOKEN }}`, con permisos mínimos `contents: read` y `concurrency` (grupo `deploy-fly-main`, `cancel-in-progress: true`) para cancelar despliegues anteriores.

### Testing

- Verifiqué sintaxis y guards del workflow con `npx prettier --check .github/workflows/deploy.yml` y comprobaciones programáticas `grep` de las condiciones de seguridad.
- Ejecuté la verificación de formato y guardas de despliegue y confirmaron la presencia de `workflow_run` para `CI`, el `ref` de `head_sha`, y el uso de `FLY_API_TOKEN` en el paso de deploy.
- Corrí `npm run lint`, `npm run test -- --runInBand` (24 suites, 137 tests pasados) y `npm run build`, y todas las comprobaciones locales pasaron exitosamente.
- No se instaló `actionlint` en este entorno por restricciones externas, pero la sintaxis fue validada con Prettier y con comprobaciones directas de las condiciones del workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e81497020833094f50d3df0396986)