### PR TITLE
feat(payment-methods): disponibilidad por tablero para medios personales

### DIFF
--- a/src/participants/participants.service.ts
+++ b/src/participants/participants.service.ts
@@ -83,6 +83,14 @@ export class ParticipantsService {
     }
   }
 
+  async ensureBoardParticipantAccess(
+    boardId: string,
+    userId: string,
+  ): Promise<void> {
+    await this.ensureBoardExists(boardId);
+    await this.ensureParticipantAccess(boardId, userId);
+  }
+
   private async checkExistingUserAndParticipant(
     tripId: string,
     email: string,

--- a/src/payment-methods/dto/update-board-visibility.dto.ts
+++ b/src/payment-methods/dto/update-board-visibility.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class UpdateBoardVisibilityDto {
+  @IsBoolean()
+  enabled: boolean;
+}

--- a/src/payment-methods/payment-method-board-exclusion.schema.ts
+++ b/src/payment-methods/payment-method-board-exclusion.schema.ts
@@ -1,0 +1,24 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+@Schema({ timestamps: true, collection: 'paymentmethodboardexclusions' })
+export class PaymentMethodBoardExclusion {
+  @Prop({ type: Types.ObjectId, ref: 'PaymentMethod', required: true })
+  paymentMethodId: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: 'Board', required: true })
+  tripId: Types.ObjectId;
+}
+
+export type PaymentMethodBoardExclusionDocument = PaymentMethodBoardExclusion &
+  Document;
+
+export const PaymentMethodBoardExclusionSchema = SchemaFactory.createForClass(
+  PaymentMethodBoardExclusion,
+);
+
+PaymentMethodBoardExclusionSchema.index(
+  { paymentMethodId: 1, tripId: 1 },
+  { unique: true },
+);
+PaymentMethodBoardExclusionSchema.index({ tripId: 1, paymentMethodId: 1 });

--- a/src/payment-methods/payment-methods.controller.ts
+++ b/src/payment-methods/payment-methods.controller.ts
@@ -17,6 +17,7 @@ import { UpdatePaymentMethodDto } from './dto/update-payment-method.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { GetUser } from '../auth/decorators/get-user.decorator';
 import { UserDocument } from '../users/user.schema';
+import { UpdateBoardVisibilityDto } from './dto/update-board-visibility.dto';
 
 @Controller('payment-methods')
 @UseGuards(JwtAuthGuard)
@@ -51,6 +52,16 @@ export class PaymentMethodsController {
     const inactive = includeInactive === 'true';
 
     if (scope === 'user') {
+      if (resolvedBoardId) {
+        const paymentMethods =
+          await this.paymentMethodsService.findUserMethodsForBoard(
+            resolvedBoardId,
+            user._id.toString(),
+            inactive,
+          );
+        return { paymentMethods };
+      }
+
       const paymentMethods = await this.paymentMethodsService.findByUser(
         user._id.toString(),
         inactive,
@@ -82,6 +93,28 @@ export class PaymentMethodsController {
       inactive,
     );
     return { paymentMethods };
+  }
+
+  @Patch(':paymentMethodId/boards/:boardId/visibility')
+  async updateBoardVisibility(
+    @Param('paymentMethodId') paymentMethodId: string,
+    @Param('boardId') boardId: string,
+    @Body() dto: UpdateBoardVisibilityDto,
+    @GetUser() user: UserDocument,
+  ) {
+    const visibility = await this.paymentMethodsService.updateBoardVisibility(
+      paymentMethodId,
+      boardId,
+      dto.enabled,
+      user._id.toString(),
+    );
+
+    return {
+      message: dto.enabled
+        ? 'Medio de pago habilitado en el tablero'
+        : 'Medio de pago ocultado en el tablero',
+      visibility,
+    };
   }
 
   @Get(':id')

--- a/src/payment-methods/payment-methods.module.ts
+++ b/src/payment-methods/payment-methods.module.ts
@@ -5,12 +5,20 @@ import { PaymentMethodsController } from './payment-methods.controller';
 import { PaymentMethod, PaymentMethodSchema } from './payment-method.schema';
 import { ParticipantsModule } from '../participants/participants.module';
 import { Card, CardSchema } from '../cards/card.schema';
+import {
+  PaymentMethodBoardExclusion,
+  PaymentMethodBoardExclusionSchema,
+} from './payment-method-board-exclusion.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: PaymentMethod.name, schema: PaymentMethodSchema },
       { name: Card.name, schema: CardSchema },
+      {
+        name: PaymentMethodBoardExclusion.name,
+        schema: PaymentMethodBoardExclusionSchema,
+      },
     ]),
     forwardRef(() => ParticipantsModule),
   ],

--- a/src/payment-methods/payment-methods.service.spec.ts
+++ b/src/payment-methods/payment-methods.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/mongoose';
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { Types } from 'mongoose';
 import { PaymentMethodsService } from './payment-methods.service';
 import {
@@ -10,6 +14,7 @@ import {
 } from './payment-method.schema';
 import { Card } from '../cards/card.schema';
 import { ParticipantsService } from '../participants/participants.service';
+import { PaymentMethodBoardExclusion } from './payment-method-board-exclusion.schema';
 
 describe('PaymentMethodsService', () => {
   let service: PaymentMethodsService;
@@ -17,6 +22,7 @@ describe('PaymentMethodsService', () => {
   const boardId = new Types.ObjectId();
   const userId = new Types.ObjectId().toString();
   const otherUserId = new Types.ObjectId().toString();
+  const otherBoardId = new Types.ObjectId();
   const methodId = new Types.ObjectId();
 
   const modelMethods = {
@@ -40,8 +46,15 @@ describe('PaymentMethodsService', () => {
     find: jest.fn().mockResolvedValue([]),
   };
 
+  const visibilityModel = {
+    find: jest.fn(),
+    updateOne: jest.fn(),
+    deleteOne: jest.fn(),
+  };
+
   const participantsService = {
     ensureParticipantAccess: jest.fn(),
+    ensureBoardParticipantAccess: jest.fn(),
     findByTrip: jest.fn(),
   };
 
@@ -57,6 +70,10 @@ describe('PaymentMethodsService', () => {
           useValue: paymentMethodModel,
         },
         { provide: getModelToken(Card.name), useValue: cardModel },
+        {
+          provide: getModelToken(PaymentMethodBoardExclusion.name),
+          useValue: visibilityModel,
+        },
         { provide: ParticipantsService, useValue: participantsService },
       ],
     }).compile();
@@ -146,6 +163,9 @@ describe('PaymentMethodsService', () => {
         { userId: new Types.ObjectId(userId) },
       ]);
       modelMethods.countDocuments.mockResolvedValue(1);
+      visibilityModel.find.mockReturnValue({
+        distinct: jest.fn().mockResolvedValue([]),
+      });
 
       const chain = {
         populate: jest.fn().mockReturnThis(),
@@ -167,7 +187,216 @@ describe('PaymentMethodsService', () => {
       );
 
       expect(modelMethods.find).toHaveBeenCalled();
+      expect(modelMethods.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          $or: expect.arrayContaining([
+            expect.objectContaining({
+              ownerType: PaymentMethodOwnerType.USER,
+              _id: { $nin: [] },
+            }),
+          ]),
+        }),
+      );
       expect(result).toHaveLength(1);
+    });
+
+    it('excludes only personal methods disabled for the requested board', async () => {
+      const disabledMethodId = new Types.ObjectId();
+      participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+      participantsService.findByTrip.mockResolvedValue([
+        { userId: new Types.ObjectId(userId) },
+      ]);
+      modelMethods.countDocuments.mockResolvedValue(1);
+      visibilityModel.find.mockImplementation(
+        (filter: { tripId: Types.ObjectId }) => ({
+          distinct: jest
+            .fn()
+            .mockResolvedValue(
+              filter.tripId.toString() === boardId.toString()
+                ? [disabledMethodId]
+                : [],
+            ),
+        }),
+      );
+      modelMethods.find.mockReturnValue({
+        populate: jest.fn().mockReturnThis(),
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      await service.findAvailableForBoard(boardId.toString(), userId);
+      expect(modelMethods.find).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          $or: expect.arrayContaining([
+            expect.objectContaining({ _id: { $nin: [disabledMethodId] } }),
+          ]),
+        }),
+      );
+
+      await service.findAvailableForBoard(otherBoardId.toString(), userId);
+      expect(modelMethods.find).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          $or: expect.arrayContaining([
+            expect.objectContaining({ _id: { $nin: [] } }),
+          ]),
+        }),
+      );
+    });
+
+    it('keeps board-owned methods and filters inactive methods as before', async () => {
+      participantsService.ensureParticipantAccess.mockResolvedValue(undefined);
+      participantsService.findByTrip.mockResolvedValue([]);
+      modelMethods.countDocuments.mockResolvedValue(1);
+      visibilityModel.find.mockReturnValue({
+        distinct: jest.fn().mockResolvedValue([]),
+      });
+      modelMethods.find.mockReturnValue({
+        populate: jest.fn().mockReturnThis(),
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      await service.findAvailableForBoard(boardId.toString(), userId);
+
+      expect(modelMethods.find).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          $or: expect.arrayContaining([
+            expect.objectContaining({
+              ownerType: PaymentMethodOwnerType.BOARD,
+              isActive: true,
+            }),
+            expect.objectContaining({
+              ownerType: PaymentMethodOwnerType.USER,
+              isActive: true,
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
+  describe('board visibility', () => {
+    const personalMethod = {
+      _id: methodId,
+      ownerType: PaymentMethodOwnerType.USER,
+      userId: new Types.ObjectId(userId),
+    };
+
+    it('reports personal methods as enabled by default and includes the owner', async () => {
+      participantsService.ensureBoardParticipantAccess.mockResolvedValue(
+        undefined,
+      );
+      modelMethods.find.mockReturnValue({
+        populate: jest.fn().mockReturnThis(),
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([personalMethod]),
+      });
+      visibilityModel.find.mockReturnValue({
+        distinct: jest.fn().mockResolvedValue([]),
+      });
+
+      const methods = await service.findUserMethodsForBoard(
+        boardId.toString(),
+        userId,
+      );
+
+      expect(methods[0]).toEqual(expect.objectContaining({ enabled: true }));
+    });
+
+    it('hides by upserting an exclusion without modifying the payment method', async () => {
+      modelMethods.findById.mockResolvedValue(personalMethod);
+      visibilityModel.updateOne.mockResolvedValue({ upsertedCount: 1 });
+
+      const result = await service.updateBoardVisibility(
+        methodId.toString(),
+        boardId.toString(),
+        false,
+        userId,
+      );
+
+      expect(visibilityModel.updateOne).toHaveBeenCalledWith(
+        expect.objectContaining({ paymentMethodId: methodId }),
+        expect.any(Object),
+        { upsert: true },
+      );
+      expect(result.enabled).toBe(false);
+      expect(personalMethod).not.toHaveProperty('isActive');
+    });
+
+    it('re-enables by deleting the exclusion', async () => {
+      modelMethods.findById.mockResolvedValue(personalMethod);
+      visibilityModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+
+      const result = await service.updateBoardVisibility(
+        methodId.toString(),
+        boardId.toString(),
+        true,
+        userId,
+      );
+
+      expect(visibilityModel.deleteOne).toHaveBeenCalled();
+      expect(result.enabled).toBe(true);
+    });
+
+    it('rejects a participant who does not own the personal method', async () => {
+      modelMethods.findById.mockResolvedValue(personalMethod);
+
+      await expect(
+        service.updateBoardVisibility(
+          methodId.toString(),
+          boardId.toString(),
+          false,
+          otherUserId,
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(visibilityModel.updateOne).not.toHaveBeenCalled();
+    });
+
+    it('rejects board-owned methods', async () => {
+      modelMethods.findById.mockResolvedValue({
+        _id: methodId,
+        ownerType: PaymentMethodOwnerType.BOARD,
+        tripId: boardId,
+      });
+
+      await expect(
+        service.updateBoardVisibility(
+          methodId.toString(),
+          boardId.toString(),
+          false,
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects missing methods', async () => {
+      modelMethods.findById.mockResolvedValue(null);
+
+      await expect(
+        service.updateBoardVisibility(
+          methodId.toString(),
+          boardId.toString(),
+          false,
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('requires an existing board and owner participation', async () => {
+      modelMethods.findById.mockResolvedValue(personalMethod);
+      participantsService.ensureBoardParticipantAccess.mockRejectedValue(
+        new ForbiddenException('No tienes acceso'),
+      );
+
+      await expect(
+        service.updateBoardVisibility(
+          methodId.toString(),
+          boardId.toString(),
+          false,
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(visibilityModel.updateOne).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/payment-methods/payment-methods.service.ts
+++ b/src/payment-methods/payment-methods.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
   Logger,
   OnModuleInit,
 } from '@nestjs/common';
@@ -20,6 +21,14 @@ import { resolveBoardId } from '../common/utils/resolve-board-id';
 import { Card, CardDocument } from '../cards/card.schema';
 import { UserDocument } from '../users/user.schema';
 import { DEFAULT_PAYMENT_METHODS } from './constants/default-payment-methods';
+import {
+  PaymentMethodBoardExclusion,
+  PaymentMethodBoardExclusionDocument,
+} from './payment-method-board-exclusion.schema';
+
+export type PaymentMethodWithBoardVisibility = PaymentMethod & {
+  enabled: boolean;
+};
 
 @Injectable()
 export class PaymentMethodsService implements OnModuleInit {
@@ -30,6 +39,8 @@ export class PaymentMethodsService implements OnModuleInit {
     private paymentMethodModel: Model<PaymentMethodDocument>,
     @InjectModel(Card.name)
     private cardModel: Model<CardDocument>,
+    @InjectModel(PaymentMethodBoardExclusion.name)
+    private paymentMethodBoardExclusionModel: Model<PaymentMethodBoardExclusionDocument>,
     private participantsService: ParticipantsService,
   ) {}
 
@@ -233,6 +244,10 @@ export class PaymentMethodsService implements OnModuleInit {
     );
     const participantUserIds = this.extractParticipantUserIds(participants);
 
+    const disabledPersonalMethods = await this.paymentMethodBoardExclusionModel
+      .find({ tripId: new Types.ObjectId(boardId) })
+      .distinct('paymentMethodId');
+
     const activeFilter = includeInactive ? {} : { isActive: true };
 
     return this.paymentMethodModel
@@ -246,6 +261,7 @@ export class PaymentMethodsService implements OnModuleInit {
           {
             ownerType: PaymentMethodOwnerType.USER,
             userId: { $in: participantUserIds },
+            _id: { $nin: disabledPersonalMethods },
             ...activeFilter,
           },
         ],
@@ -254,6 +270,84 @@ export class PaymentMethodsService implements OnModuleInit {
       .populate('tripId', 'name')
       .sort({ isDefault: -1, ownerType: 1, kind: 1, name: 1 })
       .lean();
+  }
+
+  async findUserMethodsForBoard(
+    boardId: string,
+    userId: string,
+    includeInactive = false,
+  ): Promise<PaymentMethodWithBoardVisibility[]> {
+    await this.participantsService.ensureBoardParticipantAccess(
+      boardId,
+      userId,
+    );
+
+    const methods = await this.paymentMethodModel
+      .find({
+        ownerType: PaymentMethodOwnerType.USER,
+        userId: new Types.ObjectId(userId),
+        ...(includeInactive ? {} : { isActive: true }),
+      })
+      .populate('userId', 'firstName lastName')
+      .sort({ kind: 1, name: 1 })
+      .lean();
+
+    const disabledIds = await this.paymentMethodBoardExclusionModel
+      .find({
+        tripId: new Types.ObjectId(boardId),
+        paymentMethodId: { $in: methods.map((method) => method._id) },
+      })
+      .distinct('paymentMethodId');
+    const disabledIdSet = new Set(disabledIds.map((id) => id.toString()));
+
+    return methods.map((method) => ({
+      ...method,
+      enabled: !disabledIdSet.has(method._id.toString()),
+    })) as PaymentMethodWithBoardVisibility[];
+  }
+
+  async updateBoardVisibility(
+    paymentMethodId: string,
+    boardId: string,
+    enabled: boolean,
+    userId: string,
+  ): Promise<{ paymentMethodId: string; boardId: string; enabled: boolean }> {
+    const method = await this.paymentMethodModel.findById(paymentMethodId);
+
+    if (!method) {
+      throw new NotFoundException('Medio de pago no encontrado');
+    }
+    if (method.ownerType !== PaymentMethodOwnerType.USER) {
+      throw new BadRequestException(
+        'La disponibilidad por tablero solo aplica a medios personales',
+      );
+    }
+    if (method.userId?.toString() !== userId) {
+      throw new ForbiddenException(
+        'Solo el propietario puede cambiar la disponibilidad de este medio de pago',
+      );
+    }
+
+    await this.participantsService.ensureBoardParticipantAccess(
+      boardId,
+      userId,
+    );
+
+    const relation = {
+      paymentMethodId: method._id,
+      tripId: new Types.ObjectId(boardId),
+    };
+    if (enabled) {
+      await this.paymentMethodBoardExclusionModel.deleteOne(relation);
+    } else {
+      await this.paymentMethodBoardExclusionModel.updateOne(
+        relation,
+        { $setOnInsert: relation },
+        { upsert: true },
+      );
+    }
+
+    return { paymentMethodId, boardId, enabled };
   }
 
   async findOne(id: string, userId: string): Promise<PaymentMethod> {
@@ -329,10 +423,14 @@ export class PaymentMethodsService implements OnModuleInit {
   }
 
   async deleteByBoard(boardId: string): Promise<void> {
-    await this.paymentMethodModel.deleteMany({
-      ownerType: PaymentMethodOwnerType.BOARD,
-      tripId: new Types.ObjectId(boardId),
-    });
+    const tripId = new Types.ObjectId(boardId);
+    await Promise.all([
+      this.paymentMethodModel.deleteMany({
+        ownerType: PaymentMethodOwnerType.BOARD,
+        tripId,
+      }),
+      this.paymentMethodBoardExclusionModel.deleteMany({ tripId }),
+    ]);
   }
 
   private async ensureCanAccess(


### PR DESCRIPTION
### Motivation

- Actualmente los medios `USER` aparecen automáticamente en todos los tableros de sus propietarios, y se requiere permitir que el propietario decida disponibilidad por tablero sin duplicar recursos.
- La solución debe ser backwards-compatible: por defecto un medio personal permanece habilitado salvo exclusión explícita.

### Description

- Se agregó la colección `paymentmethodboardexclusions` para almacenar solo exclusiones explícitas `{ paymentMethodId, tripId }` y evitar arrays ilimitados dentro de documentos existentes.
- Se añadió el endpoint `PATCH /payment-methods/:paymentMethodId/boards/:boardId/visibility` con el DTO `UpdateBoardVisibilityDto` (`{ enabled: boolean }`) y la lógica idempotente para insertar/eliminar la exclusión según `enabled`.
- `findAvailableForBoard(boardId, userId)` ahora consulta las exclusiones del `boardId` y excluye únicamente los medios `USER` listados allí, manteniendo `BOARD` methods, `populate`, orden y filtro `isActive` por defecto; además se añadió `findUserMethodsForBoard(boardId, userId)` que devuelve los medios personales del usuario con `enabled: boolean` calculado.
- Se añadieron validaciones de permisos para que solo el propietario del `PaymentMethod` y participante del tablero pueda cambiar la visibilidad, y se añadió `ensureBoardParticipantAccess` en `ParticipantsService`; al borrar un tablero también se limpian sus exclusiones.
- Archivos principales modificados: `src/payment-methods/payment-method-board-exclusion.schema.ts`, `src/payment-methods/dto/update-board-visibility.dto.ts`, `src/payment-methods/payment-methods.module.ts`, `src/payment-methods/payment-methods.controller.ts`, `src/payment-methods/payment-methods.service.ts`, `src/payment-methods/payment-methods.service.spec.ts`, y `src/participants/participants.service.ts`.

### Testing

- Se ejecutó `npm run lint` y completó sin errores (se conservaron 4 warnings de tipos en specs relacionados con mocks). 
- Se ejecutaron los tests con `npm test -- --runInBand` y todos los suites pasaron: 24 suites, 146 tests pasando.
- Se ejecutó `npm run build` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7fb2e612748330bd5c9db9d8c8f21e)