### PR TITLE
feat(payment-methods): add read-only scope to list participants' personal payment methods

### DIFF
--- a/src/payment-methods/payment-methods.controller.ts
+++ b/src/payment-methods/payment-methods.controller.ts
@@ -10,6 +10,7 @@ import {
   HttpStatus,
   UseGuards,
   Query,
+  BadRequestException,
 } from '@nestjs/common';
 import { PaymentMethodsService } from './payment-methods.service';
 import { CreatePaymentMethodDto } from './dto/create-payment-method.dto';
@@ -50,6 +51,21 @@ export class PaymentMethodsController {
   ) {
     const resolvedBoardId = boardId || tripId;
     const inactive = includeInactive === 'true';
+
+    if (scope === 'board-participants') {
+      if (!resolvedBoardId) {
+        throw new BadRequestException(
+          'boardId o tripId es requerido para consultar participantes',
+        );
+      }
+
+      const paymentMethods =
+        await this.paymentMethodsService.findParticipantMethodsForBoard(
+          resolvedBoardId,
+          user._id.toString(),
+        );
+      return { paymentMethods };
+    }
 
     if (scope === 'user') {
       if (resolvedBoardId) {

--- a/src/payment-methods/payment-methods.service.spec.ts
+++ b/src/payment-methods/payment-methods.service.spec.ts
@@ -282,6 +282,95 @@ describe('PaymentMethodsService', () => {
       userId: new Types.ObjectId(userId),
     };
 
+    describe('participant configuration query', () => {
+      const secondMethodId = new Types.ObjectId();
+      const participantMethods = [
+        {
+          ...personalMethod,
+          kind: PaymentMethodKind.CREDIT,
+          name: 'Personal Visa',
+          isActive: true,
+        },
+        {
+          _id: secondMethodId,
+          ownerType: PaymentMethodOwnerType.USER,
+          userId: new Types.ObjectId(otherUserId),
+          kind: PaymentMethodKind.DEBIT,
+          name: 'Other debit',
+          isActive: true,
+        },
+      ];
+
+      beforeEach(() => {
+        participantsService.ensureBoardParticipantAccess.mockResolvedValue(
+          undefined,
+        );
+        participantsService.findByTrip.mockResolvedValue([
+          { userId: new Types.ObjectId(userId) },
+          { userId: new Types.ObjectId(otherUserId) },
+        ]);
+        modelMethods.find.mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          populate: jest.fn().mockReturnThis(),
+          sort: jest.fn().mockReturnThis(),
+          lean: jest.fn().mockResolvedValue(participantMethods),
+        });
+      });
+
+      it('allows a participant and returns active personal methods for every participant', async () => {
+        visibilityModel.find.mockReturnValue({
+          distinct: jest.fn().mockResolvedValue([]),
+        });
+
+        const methods = await service.findParticipantMethodsForBoard(
+          boardId.toString(),
+          userId,
+        );
+
+        expect(
+          participantsService.ensureBoardParticipantAccess,
+        ).toHaveBeenCalledWith(boardId.toString(), userId);
+        expect(modelMethods.find).toHaveBeenCalledWith({
+          ownerType: PaymentMethodOwnerType.USER,
+          userId: {
+            $in: [new Types.ObjectId(userId), new Types.ObjectId(otherUserId)],
+          },
+          isActive: true,
+        });
+        expect(methods).toHaveLength(2);
+      });
+
+      it('returns enabled and disabled methods according to this board exclusions', async () => {
+        visibilityModel.find.mockReturnValue({
+          distinct: jest.fn().mockResolvedValue([secondMethodId]),
+        });
+
+        const methods = await service.findParticipantMethodsForBoard(
+          boardId.toString(),
+          userId,
+        );
+
+        expect(methods).toEqual([
+          expect.objectContaining({ _id: methodId, enabled: true }),
+          expect.objectContaining({ _id: secondMethodId, enabled: false }),
+        ]);
+      });
+
+      it('rejects users outside the board before reading payment methods', async () => {
+        participantsService.ensureBoardParticipantAccess.mockRejectedValue(
+          new ForbiddenException('No tienes acceso'),
+        );
+
+        await expect(
+          service.findParticipantMethodsForBoard(
+            boardId.toString(),
+            otherUserId,
+          ),
+        ).rejects.toBeInstanceOf(ForbiddenException);
+        expect(modelMethods.find).not.toHaveBeenCalled();
+      });
+    });
+
     it('reports personal methods as enabled by default and includes the owner', async () => {
       participantsService.ensureBoardParticipantAccess.mockResolvedValue(
         undefined,

--- a/src/payment-methods/payment-methods.service.ts
+++ b/src/payment-methods/payment-methods.service.ts
@@ -306,6 +306,46 @@ export class PaymentMethodsService implements OnModuleInit {
     })) as PaymentMethodWithBoardVisibility[];
   }
 
+  async findParticipantMethodsForBoard(
+    boardId: string,
+    userId: string,
+  ): Promise<PaymentMethodWithBoardVisibility[]> {
+    await this.participantsService.ensureBoardParticipantAccess(
+      boardId,
+      userId,
+    );
+
+    const participants = await this.participantsService.findByTrip(
+      boardId,
+      userId,
+    );
+    const participantUserIds = this.extractParticipantUserIds(participants);
+
+    const methods = await this.paymentMethodModel
+      .find({
+        ownerType: PaymentMethodOwnerType.USER,
+        userId: { $in: participantUserIds },
+        isActive: true,
+      })
+      .select('_id ownerType kind name lastFourDigits isActive userId')
+      .populate('userId', '_id firstName lastName')
+      .sort({ kind: 1, name: 1 })
+      .lean();
+
+    const disabledIds = await this.paymentMethodBoardExclusionModel
+      .find({
+        tripId: new Types.ObjectId(boardId),
+        paymentMethodId: { $in: methods.map((method) => method._id) },
+      })
+      .distinct('paymentMethodId');
+    const disabledIdSet = new Set(disabledIds.map((id) => id.toString()));
+
+    return methods.map((method) => ({
+      ...method,
+      enabled: !disabledIdSet.has(method._id.toString()),
+    })) as PaymentMethodWithBoardVisibility[];
+  }
+
   async updateBoardVisibility(
     paymentMethodId: string,
     boardId: string,


### PR DESCRIPTION
### Motivation

- Provide a read-only query so any authorized board participant can view all active personal payment methods of every participant (both enabled and disabled for that board) without allowing modifications. 

### Description

- Added `scope=board-participants` handling to `GET /payment-methods` which requires `boardId`/`tripId` and returns the participant-focused response. 
- Implemented `PaymentMethodsService.findParticipantMethodsForBoard(boardId, userId)` which enforces board-participant authorization, loads participant user IDs, queries active `ownerType: USER` methods for those users, restricts selected fields to `_id ownerType kind name lastFourDigits isActive userId`, populates `userId` with `_id, firstName, lastName`, and computes `enabled` using existing board exclusions. 
- Endpoint is strictly read-only and does not change existing mutation rules; the existing `PATCH .../visibility` remains owner-only and `findAvailableForBoard()` was left unchanged to continue returning only methods usable for new movements. 
- Added unit tests covering authorized participant access, rejection of non-participants, returning methods for all participants, inclusion of enabled/disabled states per board exclusions, and ensuring inactive methods are not returned.

### Testing

- Ran the focused service spec with `npm test -- --runInBand src/payment-methods/payment-methods.service.spec.ts` and it passed (18 tests passed). 
- Ran full test suite with `npm run test -- --runInBand` and it passed (24 suites, 149 tests passed). 
- Ran lint with `npm run lint` which completed with no errors and reported 4 existing TypeScript `no-unsafe-assignment` warnings in tests only. 
- Built the project with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7fc3489958833094e74f9faf28ac2c)